### PR TITLE
Enhance CLI and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Test
         run: pytest
       - name: Generate spec
-        run: python -m src.cli generate --market crypto --output specs/openapi_crypto.yaml
+        run: tvgen generate --market crypto --output specs/openapi_crypto.yaml
       - name: Validate OpenAPI
         run: openapi-spec-validator specs/openapi_crypto.yaml
       - uses: stefanzweifel/git-auto-commit-action@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,13 +52,13 @@
 6. **Generate OpenAPI spec**
 
    ```bash
-   python -m src.cli generate --market crypto --output specs/openapi_crypto.yaml
+   tvgen generate --market crypto --output specs/openapi_crypto.yaml
    ```
 
 7. **Validate spec**
 
    ```bash
-   openapi-spec-validator specs/openapi_crypto.yaml
+   tvgen validate --spec specs/openapi_crypto.yaml
    ```
 
 8. **Commit changes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+- Refactored CLI to use `click`
+- Added CLI unit tests
+- Updated documentation and CI workflow
 ## 0.2.0
 - Removed legacy root scripts
 - Added new `tvgen` CLI commands

--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ pip install -r requirements.txt
 ### Scan a market
 
 ```bash
-python -m src.cli scan --market crypto
+tvgen scan --market crypto
 ```
 
 ### Generate an OpenAPI spec
 
 ```bash
-python -m src.cli generate --market crypto --output specs/openapi_crypto.yaml
+tvgen generate --market crypto --output specs/openapi_crypto.yaml
 ```
 
 ### Validate a spec
 
 ```bash
-python -m src.cli validate --spec specs/openapi_crypto.yaml
+tvgen validate --spec specs/openapi_crypto.yaml
 ```
 
 ## Tests
@@ -36,6 +36,15 @@ pytest
 
 ## CI/CD
 
-The GitHub Actions workflow formats code, lints, runs type checks and unit
-tests, generates the crypto specification and validates it. Any changed files in
-`specs/` are automatically committed back to the repository.
+The GitHub Actions workflow performs the following steps on every push and
+weekly schedule:
+
+1. `black --check .`
+2. `flake8 .`
+3. `mypy src/`
+4. `pytest`
+5. `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
+6. `openapi-spec-validator specs/openapi_crypto.yaml`
+
+If the generated specification changes, the workflow automatically commits the
+updated file back to the repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,16 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.2.0"
+version = "0.3.0"
+
+[project.scripts]
+tvgen = "src.cli:cli"
+
+[tool.setuptools]
+packages = ["src", "src.api", "src.generator", "src.utils"]
+
+[tool.setuptools.package-dir]
+src = "src"
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/specs/openapi_crypto.yaml
+++ b/specs/openapi_crypto.yaml
@@ -17,4 +17,4 @@ components:
         close:
           type: number
         open:
-          type: number
+          type: string

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+import yaml
+import requests_mock
+from click.testing import CliRunner
+
+from src.cli import cli
+from src.generator.openapi_generator import OpenAPIGenerator
+
+
+def _create_field_status(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("field\tstatus\tvalue\n")
+        f.write("close\tok\t1\n")
+        f.write("open\tok\tabc\n")
+
+
+def test_cli_scan() -> None:
+    runner = CliRunner()
+    with requests_mock.Mocker() as m:
+        m.post("https://scanner.tradingview.com/crypto/scan", json={"data": []})
+        result = runner.invoke(cli, ["scan", "--market", "crypto"])
+        assert result.exit_code == 0
+        assert "data" in result.output
+
+
+def test_cli_generate_and_validate(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        market_dir = Path("results") / "crypto"
+        _create_field_status(market_dir / "field_status.tsv")
+
+        out_file = Path("spec.yaml")
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "--market",
+                "crypto",
+                "--output",
+                str(out_file),
+            ],
+        )
+        assert result.exit_code == 0
+
+        result = runner.invoke(cli, ["validate", "--spec", str(out_file)])
+        assert result.exit_code == 0
+        data = yaml.safe_load(out_file.read_text())
+        assert "/crypto/scan" in data["paths"]


### PR DESCRIPTION
## Summary
- refactor CLI to use `click`
- update README and AGENTS docs
- add CLI unit tests
- update workflow for new CLI
- bump version to 0.3.0
- regenerate crypto spec

## Testing
- `black . --check`
- `flake8 .`
- `mypy src`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `openapi-spec-validator specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68476d38fc68832ca0a00ac177347123