### PR TITLE
Refactor tests and docs, update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Lint
         run: flake8 .
       - name: Type check
-        run: mypy src
+        run: mypy src/
       - name: Test
-        run: pytest
+        run: pytest -q
       - name: Generate spec
         run: tvgen generate --market crypto --output specs/openapi_crypto.yaml
       - name: Validate OpenAPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0
+- Improved CLI tests and removed path hacks
+- Cleaned repository and added CI badge
+- Updated workflow to use `pytest -q`
+- Documentation improvements
+
 ## 0.3.0
 - Refactored CLI to use `click`
 - Added CLI unit tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tv-generator
 
+[![CI](https://github.com/your-org/tv-generator/actions/workflows/ci.yml/badge.svg)](https://github.com/your-org/tv-generator/actions/workflows/ci.yml)
+
 Utilities for interacting with the TradingView Screener API and generating an OpenAPI specification.
 
 ## Installation
@@ -8,21 +10,21 @@ Utilities for interacting with the TradingView Screener API and generating an Op
 pip install -r requirements.txt
 ```
 
-## Usage
+## Running
 
-### Scan a market
+Scan a market:
 
 ```bash
 tvgen scan --market crypto
 ```
 
-### Generate an OpenAPI spec
+Generate an OpenAPI spec:
 
 ```bash
 tvgen generate --market crypto --output specs/openapi_crypto.yaml
 ```
 
-### Validate a spec
+Validate a spec file:
 
 ```bash
 tvgen validate --spec specs/openapi_crypto.yaml
@@ -30,21 +32,25 @@ tvgen validate --spec specs/openapi_crypto.yaml
 
 ## Tests
 
+Run the full test suite:
+
 ```bash
-pytest
+pytest -q
 ```
+
+To add tests, place new files under the `tests/` directory. Each test file should start with `test_` and use `pytest` assertions. Command line behaviour can be tested with `click.testing.CliRunner`.
 
 ## CI/CD
 
-The GitHub Actions workflow performs the following steps on every push and
-weekly schedule:
+The GitHub Actions workflow runs on every push and pull request. It performs formatting, linting, type checking, tests, spec generation and validation. If any step fails the workflow fails.
 
-1. `black --check .`
-2. `flake8 .`
-3. `mypy src/`
-4. `pytest`
-5. `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
-6. `openapi-spec-validator specs/openapi_crypto.yaml`
+```text
+black --check .
+flake8 .
+mypy src/
+pytest -q
+tvgen generate --market crypto --output specs/openapi_crypto.yaml
+openapi-spec-validator specs/openapi_crypto.yaml
+```
 
-If the generated specification changes, the workflow automatically commits the
-updated file back to the repository.
+If tests fail locally ensure that dependencies are installed with `pip install -r requirements.txt`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.3.0"
+version = "0.4.0"
 
 [project.scripts]
 tvgen = "src.cli:cli"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,10 @@
-import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 import yaml
 import requests_mock
 from click.testing import CliRunner
 
 from src.cli import cli
-from src.generator.openapi_generator import OpenAPIGenerator
 
 
 def _create_field_status(path: Path) -> None:
@@ -25,6 +22,13 @@ def test_cli_scan() -> None:
         result = runner.invoke(cli, ["scan", "--market", "crypto"])
         assert result.exit_code == 0
         assert "data" in result.output
+
+
+def test_cli_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "TradingView" in result.output
 
 
 def test_cli_generate_and_validate(tmp_path: Path) -> None:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,9 +1,3 @@
-# flake8: noqa
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
-
 from src.utils.infer import infer_type
 
 

--- a/tests/test_openapi_generator.py
+++ b/tests/test_openapi_generator.py
@@ -1,7 +1,4 @@
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 import yaml
 from src.generator.openapi_generator import OpenAPIGenerator

--- a/tests/test_tradingview_api.py
+++ b/tests/test_tradingview_api.py
@@ -1,9 +1,3 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
-
-import requests
 import requests_mock
 
 from src.api.tradingview_api import TradingViewAPI


### PR DESCRIPTION
## Summary
- clean up unit tests and remove sys.path hacks
- document installation, testing and CI usage
- bump version to 0.4.0 and note changes
- update CI workflow to use `pytest -q`

## Testing
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `openapi-spec-validator specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6847709365f8832c815cc2d6e8ac35af