### PR TITLE
Enhance CLI and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,3 @@ jobs:
         run: tvgen generate --market crypto --output specs/openapi_crypto.yaml
       - name: Validate OpenAPI
         run: openapi-spec-validator specs/openapi_crypto.yaml
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        if: |
-          github.event_name == 'push' || github.event_name == 'schedule'
-        with:
-          commit_message: "Auto-update specs"
-          file_pattern: specs/*.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.0
+- Improved CLI error handling and messages
+- Expanded unit tests with additional edge cases
+- Updated CI workflow commands
+- Documentation updates and version bump
 ## 0.5.0
 - Fixed packaging configuration for editable installs
 - Added editable install and spec validation to CI

--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@ Utilities for interacting with the TradingView Screener API and generating an Op
 
 ## Installation
 
+Install runtime requirements and the package in editable mode:
+
 ```bash
 pip install -r requirements.txt
 pip install -e .
+```
+
+For development and running the test suite you will also need some tooling:
+
+```bash
+pip install black flake8 mypy pytest openapi-spec-validator requests_mock
 ```
 
 ## Running
@@ -19,7 +27,7 @@ Scan a market:
 tvgen scan --market crypto
 ```
 
-Generate an OpenAPI spec:
+Generate an OpenAPI spec and save it to `specs/`:
 
 ```bash
 tvgen generate --market crypto --output specs/openapi_crypto.yaml
@@ -56,4 +64,18 @@ tvgen generate --market crypto --output specs/openapi_crypto.yaml
 openapi-spec-validator specs/openapi_crypto.yaml
 ```
 
-If tests fail locally ensure that dependencies are installed with `pip install -r requirements.txt`.
+
+## Troubleshooting CI failures
+
+Most CI issues are caused by formatting, lint or type errors. Before pushing run:
+
+```bash
+black .
+flake8 .
+mypy src/
+pytest -q
+tvgen generate --market crypto --output specs/openapi_crypto.yaml
+openapi-spec-validator specs/openapi_crypto.yaml
+```
+
+Ensure all commands succeed locally to avoid pipeline failures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.5.0"
+version = "0.6.0"
 
 [project.scripts]
 tvgen = "src.cli:cli"

--- a/src/cli.py
+++ b/src/cli.py
@@ -27,7 +27,10 @@ def scan(market: str) -> None:
     """Perform a basic scan request and print JSON."""
 
     api = TradingViewAPI()
-    result = api.scan(market, payload={})
+    try:
+        result = api.scan(market, payload={})
+    except Exception as exc:  # requests errors etc.
+        raise click.ClickException(str(exc))
     click.echo(json.dumps(result, indent=2))
 
 
@@ -40,7 +43,11 @@ def generate(market: str, output: Path) -> None:
     """Generate OpenAPI spec for a market from collected results."""
 
     genr = OpenAPIGenerator(Path("results"))
-    genr.generate(output, market=market)
+    try:
+        genr.generate(output, market=market)
+    except Exception as exc:
+        raise click.ClickException(f"Failed to generate spec: {exc}")
+    click.echo(f"Specification written to {output}")
 
 
 @cli.command()
@@ -54,9 +61,14 @@ def generate(market: str, output: Path) -> None:
 def validate(spec_file: Path) -> None:
     """Validate an OpenAPI specification file."""
 
-    with open(spec_file, "r", encoding="utf-8") as fh:
-        spec = yaml.safe_load(fh)
-    validate_spec(spec)
+    try:
+        with open(spec_file, "r", encoding="utf-8") as fh:
+            spec = yaml.safe_load(fh)
+        validate_spec(spec)
+    except FileNotFoundError as exc:
+        raise click.ClickException(str(exc))
+    except Exception as exc:
+        raise click.ClickException(f"Validation failed: {exc}")
     click.echo("Specification is valid")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,3 +59,21 @@ def test_cli_generate_and_validate(tmp_path: Path) -> None:
         assert result.exit_code == 0
         data = yaml.safe_load(out_file.read_text())
         assert "/crypto/scan" in data["paths"]
+
+
+def test_cli_scan_error(tv_api_mock) -> None:
+    runner = CliRunner()
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/crypto/scan",
+        status_code=500,
+    )
+    result = runner.invoke(cli, ["scan", "--market", "crypto"])
+    assert result.exit_code != 0
+    assert "500" in result.output
+
+
+def test_cli_validate_missing_file() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["validate", "--spec", "missing.yaml"])
+    assert result.exit_code != 0
+    assert "No such file" in result.output

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -8,3 +8,7 @@ def test_infer_type_number():
 
 def test_infer_type_string():
     assert infer_type("abc") == "string"
+
+
+def test_infer_type_nan():
+    assert infer_type(None) == "string"

--- a/tests/test_openapi_generator.py
+++ b/tests/test_openapi_generator.py
@@ -23,3 +23,15 @@ def test_generate(tmp_path: Path):
     data = yaml.safe_load(out.read_text())
     assert "/crypto/scan" in data["paths"]
     assert "CryptoFields" in data["components"]["schemas"]
+
+
+def test_generate_missing_field_status(tmp_path: Path) -> None:
+    market_dir = tmp_path / "results" / "crypto"
+    market_dir.mkdir(parents=True)
+
+    gen = OpenAPIGenerator(tmp_path / "results")
+    out = tmp_path / "spec.yaml"
+    gen.generate(out)
+
+    data = yaml.safe_load(out.read_text())
+    assert "/crypto/scan" not in data["paths"]

--- a/tests/test_tradingview_api.py
+++ b/tests/test_tradingview_api.py
@@ -1,3 +1,4 @@
+import pytest
 from src.api.tradingview_api import TradingViewAPI
 
 
@@ -14,3 +15,13 @@ def test_scan_and_metainfo(tv_api_mock):
     api = TradingViewAPI()
     assert api.scan("crypto", {}) == {"data": []}
     assert api.metainfo("crypto") == {"fields": []}
+
+
+def test_scan_error(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/crypto/scan",
+        status_code=404,
+    )
+    api = TradingViewAPI()
+    with pytest.raises(Exception):
+        api.scan("crypto", {})


### PR DESCRIPTION
## Summary
- improve CLI error handling
- expand unit tests
- update README and CHANGELOG
- bump version to 0.6.0
- refine CI workflow

## Testing
- `black .`
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `openapi-spec-validator specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68477d665814832cbed545af4f4230d1