### PR TITLE
Add stock data CLI commands with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.7.0
+- Added commands for stock recommendations and prices
+- Integrated external data helpers
+- Added click to dependencies and bumped version
+
 
 ## 0.6.0
 - Improved CLI error handling and messages

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Validate a spec file:
 tvgen validate --spec specs/openapi_crypto.yaml
 ```
 
+Fetch recommendation or price for a symbol:
+
+```bash
+tvgen recommend --symbol AAPL
+tvgen price --symbol AAPL
+```
+
 ## Tests
 
 Run the full test suite:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.6.0"
+version = "0.7.0"
+
+[project.dependencies]
+click = "*"
+requests = "*"
+pandas = "*"
+PyYAML = "*"
+tqdm = "*"
+openapi-spec-validator = "*"
 
 [project.scripts]
 tvgen = "src.cli:cli"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ PyYAML
 tqdm
 openapi-spec-validator
 requests_mock
+click

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+"""tv-generator package."""
+
+__all__ = ["api", "generator", "utils"]

--- a/src/api/stock_data.py
+++ b/src/api/stock_data.py
@@ -1,0 +1,36 @@
+import logging
+from typing import Any
+
+from .tradingview_api import TradingViewAPI
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_recommendation(symbol: str, market: str = "stocks") -> Any:
+    """Return trading recommendation for a symbol."""
+    api = TradingViewAPI()
+    payload = {
+        "symbols": {"tickers": [symbol], "query": {"types": []}},
+        "columns": ["Recommend.All"],
+    }
+    data = api.scan(market, payload)
+    try:
+        return data["data"][0]["d"][0]
+    except (KeyError, IndexError) as exc:
+        logger.error("Recommendation unavailable: %s", exc)
+        raise ValueError("Recommendation unavailable") from exc
+
+
+def fetch_stock_value(symbol: str, market: str = "stocks") -> Any:
+    """Return current close price for a symbol."""
+    api = TradingViewAPI()
+    payload = {
+        "symbols": {"tickers": [symbol], "query": {"types": []}},
+        "columns": ["close"],
+    }
+    data = api.scan(market, payload)
+    try:
+        return data["data"][0]["d"][0]
+    except (KeyError, IndexError) as exc:
+        logger.error("Price unavailable: %s", exc)
+        raise ValueError("Price unavailable") from exc

--- a/src/cli.py
+++ b/src/cli.py
@@ -11,6 +11,7 @@ import yaml
 from openapi_spec_validator import validate_spec
 
 from src.api.tradingview_api import TradingViewAPI
+from src.api.stock_data import fetch_recommendation, fetch_stock_value
 from src.generator.openapi_generator import OpenAPIGenerator
 
 logging.basicConfig(level=logging.INFO)
@@ -32,6 +33,32 @@ def scan(market: str) -> None:
     except Exception as exc:  # requests errors etc.
         raise click.ClickException(str(exc))
     click.echo(json.dumps(result, indent=2))
+
+
+@cli.command()
+@click.option("--symbol", required=True, help="Ticker symbol")
+@click.option("--market", default="stocks", show_default=True, help="Market name")
+def recommend(symbol: str, market: str) -> None:
+    """Fetch trading recommendation for a symbol."""
+
+    try:
+        value = fetch_recommendation(symbol, market)
+    except Exception as exc:  # pragma: no cover - click handles output
+        raise click.ClickException(str(exc))
+    click.echo(json.dumps(value))
+
+
+@cli.command(name="price")
+@click.option("--symbol", required=True, help="Ticker symbol")
+@click.option("--market", default="stocks", show_default=True, help="Market name")
+def price(symbol: str, market: str) -> None:
+    """Fetch last close price for a symbol."""
+
+    try:
+        value = fetch_stock_value(symbol, market)
+    except Exception as exc:  # pragma: no cover - click handles output
+        raise click.ClickException(str(exc))
+    click.echo(json.dumps(value))
 
 
 @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,28 @@ def test_cli_scan(tv_api_mock) -> None:
     assert "data" in result.output
 
 
+def test_cli_recommend(tv_api_mock) -> None:
+    runner = CliRunner()
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        json={"data": [{"d": ["buy"]}]},
+    )
+    result = runner.invoke(cli, ["recommend", "--symbol", "AAPL"])
+    assert result.exit_code == 0
+    assert "buy" in result.output
+
+
+def test_cli_price(tv_api_mock) -> None:
+    runner = CliRunner()
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        json={"data": [{"d": [1.0]}]},
+    )
+    result = runner.invoke(cli, ["price", "--symbol", "AAPL"])
+    assert result.exit_code == 0
+    assert "1.0" in result.output
+
+
 def test_cli_help() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["--help"])

--- a/tests/test_stock_data.py
+++ b/tests/test_stock_data.py
@@ -1,0 +1,30 @@
+from src.api.stock_data import fetch_recommendation, fetch_stock_value
+
+
+def test_fetch_recommendation(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        json={"data": [{"d": ["strong_buy"]}]},
+    )
+    assert fetch_recommendation("AAPL") == "strong_buy"
+
+
+def test_fetch_stock_value(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        json={"data": [{"d": [150.0]}]},
+    )
+    assert fetch_stock_value("AAPL") == 150.0
+
+
+def test_fetch_stock_value_error(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        json={},
+    )
+    try:
+        fetch_stock_value("AAPL")
+    except ValueError as exc:
+        assert "unavailable" in str(exc)
+    else:
+        assert False, "Expected error"


### PR DESCRIPTION
## Summary
- add `stock_data` helpers for recommendations and prices
- expose new `recommend` and `price` commands in the CLI
- document new commands in the README
- declare runtime dependencies including click in `pyproject.toml` and `requirements.txt`
- bump version and changelog
- add tests for new functionality

## Testing
- `black .`
- `flake8 .`
- `mypy src`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `openapi-spec-validator specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684788275e34832cac6e122ccab4ae88