### PR TITLE
Fix pyproject dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.7.1
+- Fixed `pyproject.toml` dependency format for editable installs
+
 ## 0.7.0
 - Added commands for stock recommendations and prices
 - Integrated external data helpers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.7.0"
-
-[project.dependencies]
-click = "*"
-requests = "*"
-pandas = "*"
-PyYAML = "*"
-tqdm = "*"
-openapi-spec-validator = "*"
+version = "0.7.1"
+dependencies = [
+    "click",
+    "requests",
+    "pandas",
+    "PyYAML",
+    "tqdm",
+    "openapi-spec-validator",
+]
 
 [project.scripts]
 tvgen = "src.cli:cli"


### PR DESCRIPTION
## Summary
- fix the dependencies format in `pyproject.toml`
- bump version and changelog

## Testing
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68478d46e04c832c8d34deb1b507c475