### PR TITLE
Add results-dir option to generate cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.7.2
+- Added `--results-dir` option to `generate` command
+- Updated tests for new option
+- Bumped version
 ## 0.7.1
 - Fixed `pyproject.toml` dependency format for editable installs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
     "click",
     "requests",

--- a/src/cli.py
+++ b/src/cli.py
@@ -64,12 +64,22 @@ def price(symbol: str, market: str) -> None:
 @cli.command()
 @click.option("--market", required=True, help="Market directory to use")
 @click.option(
-    "--output", type=click.Path(path_type=Path), required=True, help="Output YAML file"
+    "--output",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Output YAML file",
 )
-def generate(market: str, output: Path) -> None:
+@click.option(
+    "--results-dir",
+    type=click.Path(path_type=Path),
+    default="results",
+    show_default=True,
+    help="Directory with scan results",
+)
+def generate(market: str, output: Path, results_dir: Path) -> None:
     """Generate OpenAPI spec for a market from collected results."""
 
-    genr = OpenAPIGenerator(Path("results"))
+    genr = OpenAPIGenerator(results_dir)
     try:
         genr.generate(output, market=market)
     except Exception as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,7 @@ def test_generate_help() -> None:
     result = runner.invoke(cli, ["generate", "--help"])
     assert result.exit_code == 0
     assert "--market" in result.output
+    assert "--results-dir" in result.output
 
 
 def test_cli_generate_and_validate(tmp_path: Path) -> None:
@@ -73,6 +74,8 @@ def test_cli_generate_and_validate(tmp_path: Path) -> None:
                 "crypto",
                 "--output",
                 str(out_file),
+                "--results-dir",
+                str(Path("results")),
             ],
         )
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- add `--results-dir` option to `generate` CLI
- pass option to `OpenAPIGenerator`
- update tests for new parameter
- bump version to 0.7.2

## Testing
- `black .`
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml --results-dir results`
- `openapi-spec-validator specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68478fa72c58832ca88575c0b878d35d