### PR TITLE
Refactor stock value error test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.7.3
+- Improved stock data error test using `pytest.raises`
+- Bumped version
 ## 0.7.2
 - Added `--results-dir` option to `generate` command
 - Updated tests for new option

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
     "click",
     "requests",

--- a/tests/test_stock_data.py
+++ b/tests/test_stock_data.py
@@ -1,3 +1,4 @@
+import pytest
 from src.api.stock_data import fetch_recommendation, fetch_stock_value
 
 
@@ -22,9 +23,6 @@ def test_fetch_stock_value_error(tv_api_mock):
         "https://scanner.tradingview.com/stocks/scan",
         json={},
     )
-    try:
+    with pytest.raises(ValueError) as exc:
         fetch_stock_value("AAPL")
-    except ValueError as exc:
-        assert "unavailable" in str(exc)
-    else:
-        assert False, "Expected error"
+    assert "unavailable" in str(exc.value)


### PR DESCRIPTION
## Summary
- use pytest.raises in test_fetch_stock_value_error
- bump version to 0.7.3
- update changelog

## Testing
- `python -m src.cli generate --market crypto --output specs/openapi_crypto.yaml`
- `python -m src.cli validate --spec specs/openapi_crypto.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847908a0410832caca0e93df88ee5d4