### PR TITLE
Add basic package docstrings and exports

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,3 @@
+"""API wrappers for TradingView scanner."""
+
+__all__ = ["tradingview_api", "stock_data"]

--- a/src/generator/__init__.py
+++ b/src/generator/__init__.py
@@ -1,0 +1,5 @@
+"""OpenAPI specification generation tools."""
+
+from .openapi_generator import OpenAPIGenerator
+
+__all__ = ["OpenAPIGenerator"]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Shared utility functions for type inference."""
+
+from .infer import infer_type
+
+__all__ = ["infer_type"]


### PR DESCRIPTION
## Summary
- describe API, generator, and utils packages in their `__init__.py`
- expose relevant modules via `__all__`

## Testing
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68479182913c832cb00f3f4074a39082