### PR TITLE
Add boolean inference and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.7.4
+- Added boolean type inference and tests
+- Bumped version
 ## 0.7.3
 - Improved stock data error test using `pytest.raises`
 - Bumped version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
     "click",
     "requests",

--- a/src/utils/infer.py
+++ b/src/utils/infer.py
@@ -3,10 +3,19 @@ from __future__ import annotations
 import pandas as pd
 
 
-def infer_type(value: pd.Series | str | int | float | None) -> str:
+def infer_type(value: pd.Series | str | int | float | bool | None) -> str:
     """Infer OpenAPI type from a sample value."""
+    if isinstance(value, pd.Series):
+        value = value.iloc[0]
+
     if pd.isna(value):
         return "string"
+
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, str) and value.lower() in {"true", "false"}:
+        return "boolean"
+
     try:
         float(str(value))
         return "number"

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -12,3 +12,10 @@ def test_infer_type_string():
 
 def test_infer_type_nan():
     assert infer_type(None) == "string"
+
+
+def test_infer_type_boolean():
+    assert infer_type(True) == "boolean"
+    assert infer_type(False) == "boolean"
+    assert infer_type("true") == "boolean"
+    assert infer_type("False") == "boolean"


### PR DESCRIPTION
## Summary
- infer boolean type values
- test boolean inference
- bump version to 0.7.4

## Testing
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847927885e8832c8d8b75a8c75d0758