### PR TITLE
Improve generator and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.7.6
+- Improved OpenAPI generator to create output directories automatically
+- Added CLI error handling tests
+- Added fetch recommendation error test
+- Bumped version
 ## 0.7.5
 - Added request and response schemas to generated OpenAPI paths
 - Updated tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
     "click",
     "requests",

--- a/src/generator/openapi_generator.py
+++ b/src/generator/openapi_generator.py
@@ -109,6 +109,7 @@ class OpenAPIGenerator:
                 },
             }
 
+        output.parent.mkdir(parents=True, exist_ok=True)
         with open(output, "w", encoding="utf-8") as f:
             yaml.dump(openapi, f, sort_keys=False)
         logger.info("OpenAPI spec saved to %s", output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,28 @@ def test_cli_scan_error(tv_api_mock) -> None:
     assert "500" in result.output
 
 
+def test_cli_recommend_error(tv_api_mock) -> None:
+    runner = CliRunner()
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        json={},
+    )
+    result = runner.invoke(cli, ["recommend", "--symbol", "AAPL"])
+    assert result.exit_code != 0
+    assert "unavailable" in result.output
+
+
+def test_cli_price_error(tv_api_mock) -> None:
+    runner = CliRunner()
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        json={},
+    )
+    result = runner.invoke(cli, ["price", "--symbol", "AAPL"])
+    assert result.exit_code != 0
+    assert "unavailable" in result.output
+
+
 def test_cli_validate_missing_file() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["validate", "--spec", "missing.yaml"])

--- a/tests/test_stock_data.py
+++ b/tests/test_stock_data.py
@@ -26,3 +26,13 @@ def test_fetch_stock_value_error(tv_api_mock):
     with pytest.raises(ValueError) as exc:
         fetch_stock_value("AAPL")
     assert "unavailable" in str(exc.value)
+
+
+def test_fetch_recommendation_error(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        json={},
+    )
+    with pytest.raises(ValueError) as exc:
+        fetch_recommendation("AAPL")
+    assert "unavailable" in str(exc.value)


### PR DESCRIPTION
## Summary
- ensure OpenAPI generator creates parent directories
- add CLI error tests and recommendation error test
- bump version to 0.7.6

## Testing
- `black --check .`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684794dfcca4832cae395abb99f01b2d