### PR TITLE
Add spec update workflow

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -1,0 +1,46 @@
+---
+name: Update Specs
+# yamllint disable rule:truthy
+
+on:
+  workflow_dispatch: {}  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 2 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Actionlint
+        uses: rhysd/actionlint@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install requests_mock yamllint
+          pip install -e .
+      - name: Generate spec
+        run: tvgen generate --market crypto --output specs/openapi_crypto.yaml
+      - name: Validate spec
+        run: |
+          yamllint specs/openapi_crypto.yaml
+          openapi-spec-validator specs/openapi_crypto.yaml
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: specs/openapi_crypto.yaml
+          message: 'chore: update generated specifications'
+          default_author: github_actions
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: 'chore: update generated specifications'
+          title: 'Update OpenAPI specifications'
+          body: 'Automated update of generated specifications.'
+          branch: 'auto/spec-update'

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ tvgen generate --market crypto --output specs/openapi_crypto.yaml
 openapi-spec-validator specs/openapi_crypto.yaml
 ```
 
+### Automated spec updates
 
+The [`spec-update.yml`](.github/workflows/spec-update.yml) workflow runs weekly to generate and validate the OpenAPI spec. If the specification file changes, a pull request is opened automatically with the updated YAML.
 ## Troubleshooting CI failures
 
 Most CI issues are caused by formatting, lint or type errors. Before pushing run:


### PR DESCRIPTION
## Summary
- add automated spec update workflow
- document weekly spec update in README

## Testing
- `black . --check`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `openapi-spec-validator specs/openapi_crypto.yaml`
- `pytest -q`
- `yamllint .github/workflows/spec-update.yml`


------
https://chatgpt.com/codex/tasks/task_e_684796b7c5c0832ca4e6b7b49347c563