### PR TITLE
Fix spec update workflow

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -5,7 +5,7 @@ name: Update Specs
 on:
   workflow_dispatch: {}  # yamllint disable-line rule:truthy
   schedule:
-    - cron: '0 2 * * 1'
+    - cron: '0 2 * * *'
 
 jobs:
   build:
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.7
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.7.7
+- Fix spec update workflow
+- Run daily spec generation
+- Bumped version
+
 ## 0.7.6
 - Improved OpenAPI generator to create output directories automatically
 - Added CLI error handling tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
     "click",
     "requests",


### PR DESCRIPTION
## Summary
- fix CI failure due to missing actionlint@v1
- run daily spec updates
- bump version to 0.7.7

## Testing
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `openapi-spec-validator specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684798863bf4832ca18853446c7c332e