### PR TITLE
Fix outdated CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install dependencies

--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -11,12 +11,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Actionlint
         uses: rhysd/actionlint@v1.7.7
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
           message: 'chore: update generated specifications'
           default_author: github_actions
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: 'chore: update generated specifications'
           title: 'Update OpenAPI specifications'


### PR DESCRIPTION
## Summary
- update `actions/checkout`, `actions/setup-python`, and `create-pull-request` to current major versions

## Testing
- `black .`
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `openapi-spec-validator specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6848013fbce8832c8b16b34e05aab04c