### PR TITLE
Fix YAML indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.7.8
+- Fix YAML indentation for generated specs
+- Bumped version
 ## 0.7.7
 - Fix spec update workflow
 - Run daily spec generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
     "click",
     "requests",

--- a/specs/openapi_crypto.yaml
+++ b/specs/openapi_crypto.yaml
@@ -1,10 +1,11 @@
+---
 openapi: 3.1.0
 info:
   title: Unofficial TradingView Scanner API
   version: 1.0.0
   description: Auto-generated from collected field data.
 servers:
-- url: https://scanner.tradingview.com
+  - url: https://scanner.tradingview.com
 paths: {}
 components:
   schemas: {}

--- a/src/generator/openapi_generator.py
+++ b/src/generator/openapi_generator.py
@@ -5,6 +5,14 @@ from typing import Any, Dict, Iterable
 import pandas as pd
 import yaml
 
+
+class _IndentedDumper(yaml.SafeDumper):
+    """YAML dumper that indents sequences properly."""
+
+    def increase_indent(self, flow: bool = False, indentless: bool = False):
+        return super().increase_indent(flow, False)
+
+
 from src.utils.infer import infer_type
 
 logger = logging.getLogger(__name__)
@@ -111,5 +119,12 @@ class OpenAPIGenerator:
 
         output.parent.mkdir(parents=True, exist_ok=True)
         with open(output, "w", encoding="utf-8") as f:
-            yaml.dump(openapi, f, sort_keys=False)
+            yaml.dump(
+                openapi,
+                f,
+                sort_keys=False,
+                indent=2,
+                explicit_start=True,
+                Dumper=_IndentedDumper,
+            )
         logger.info("OpenAPI spec saved to %s", output)


### PR DESCRIPTION
## Summary
- ensure sequences are indented in the generated YAML
- bump version to 0.7.8
- update changelog
- regenerate crypto spec

## Testing
- `yamllint specs/openapi_crypto.yaml`
- `openapi-spec-validator specs/openapi_crypto.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684803d83d94832c9c2afbc78f5be3b8