### PR TITLE
Add metainfo command and improve payload handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Lint
         run: flake8 .
       - name: Type check
-        run: mypy src/
+        run: mypy --strict src/
       - name: Test
         run: pytest -q
       - name: Generate spec

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.7.1
+    hooks:
+      - id: mypy
+        args: ["--strict", "src/"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.7.9
+- New CLI commands `metainfo` and extended `scan` options
+- Expanded OpenAPI spec with metainfo endpoint
+- Added pre-commit and stricter CI checks
+
 ## 0.7.8
 - Fix YAML indentation for generated specs
 - Bumped version

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ pip install -e .
 For development and running the test suite you will also need some tooling:
 
 ```bash
-pip install black flake8 mypy pytest openapi-spec-validator requests_mock
+pip install black flake8 mypy pytest openapi-spec-validator requests_mock pre-commit
+```
+Then install the git hooks:
+
+```bash
+pre-commit install
 ```
 
 ## Running
@@ -24,7 +29,13 @@ pip install black flake8 mypy pytest openapi-spec-validator requests_mock
 Scan a market:
 
 ```bash
-tvgen scan --market crypto
+tvgen scan --market crypto --symbols BTCUSD --columns close
+```
+
+Fetch market metadata:
+
+```bash
+tvgen metainfo --market crypto
 ```
 
 Generate an OpenAPI spec and save it to `specs/`:
@@ -79,6 +90,7 @@ The [`spec-update.yml`](.github/workflows/spec-update.yml) workflow runs weekly 
 Most CI issues are caused by formatting, lint or type errors. Before pushing run:
 
 ```bash
+pre-commit run --all-files
 black .
 flake8 .
 mypy src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
     "click",
     "requests",

--- a/src/api/stock_data.py
+++ b/src/api/stock_data.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 from .tradingview_api import TradingViewAPI
+from src.utils.payload import build_scan_payload
 
 logger = logging.getLogger(__name__)
 
@@ -9,10 +10,7 @@ logger = logging.getLogger(__name__)
 def fetch_recommendation(symbol: str, market: str = "stocks") -> Any:
     """Return trading recommendation for a symbol."""
     api = TradingViewAPI()
-    payload = {
-        "symbols": {"tickers": [symbol], "query": {"types": []}},
-        "columns": ["Recommend.All"],
-    }
+    payload = build_scan_payload([symbol], ["Recommend.All"])
     data = api.scan(market, payload)
     try:
         return data["data"][0]["d"][0]
@@ -24,10 +22,7 @@ def fetch_recommendation(symbol: str, market: str = "stocks") -> Any:
 def fetch_stock_value(symbol: str, market: str = "stocks") -> Any:
     """Return current close price for a symbol."""
     api = TradingViewAPI()
-    payload = {
-        "symbols": {"tickers": [symbol], "query": {"types": []}},
-        "columns": ["close"],
-    }
+    payload = build_scan_payload([symbol], ["close"])
     data = api.scan(market, payload)
     try:
         return data["data"][0]["d"][0]

--- a/src/cli.py
+++ b/src/cli.py
@@ -12,6 +12,7 @@ from openapi_spec_validator import validate_spec
 
 from src.api.tradingview_api import TradingViewAPI
 from src.api.stock_data import fetch_recommendation, fetch_stock_value
+from src.utils.payload import build_scan_payload
 from src.generator.openapi_generator import OpenAPIGenerator
 
 logging.basicConfig(level=logging.INFO)
@@ -24,12 +25,15 @@ def cli() -> None:
 
 @cli.command()
 @click.option("--market", required=True, help="Market to scan")
-def scan(market: str) -> None:
+@click.option("--symbols", multiple=True, help="Ticker symbols")
+@click.option("--columns", multiple=True, help="Fields to request")
+def scan(market: str, symbols: tuple[str, ...], columns: tuple[str, ...]) -> None:
     """Perform a basic scan request and print JSON."""
 
     api = TradingViewAPI()
+    payload = build_scan_payload(symbols, columns)
     try:
-        result = api.scan(market, payload={})
+        result = api.scan(market, payload=payload)
     except Exception as exc:  # requests errors etc.
         raise click.ClickException(str(exc))
     click.echo(json.dumps(result, indent=2))
@@ -59,6 +63,19 @@ def price(symbol: str, market: str) -> None:
     except Exception as exc:  # pragma: no cover - click handles output
         raise click.ClickException(str(exc))
     click.echo(json.dumps(value))
+
+
+@cli.command()
+@click.option("--market", required=True, help="Market name")
+def metainfo(market: str) -> None:
+    """Fetch market metainfo."""
+
+    api = TradingViewAPI()
+    try:
+        data = api.metainfo(market)
+    except Exception as exc:  # pragma: no cover - click handles output
+        raise click.ClickException(str(exc))
+    click.echo(json.dumps(data, indent=2))
 
 
 @cli.command()

--- a/src/generator/openapi_generator.py
+++ b/src/generator/openapi_generator.py
@@ -92,7 +92,29 @@ class OpenAPIGenerator:
                                     }
                                 }
                             },
-                        }
+                        },
+                        "400": {"description": "Bad Request"},
+                        "500": {"description": "Server Error"},
+                    },
+                }
+            }
+
+            openapi["paths"][f"/{market}/metainfo"] = {
+                "post": {
+                    "summary": f"Get {market} metainfo",
+                    "responses": {
+                        "200": {
+                            "description": "Successful response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": f"#/components/schemas/{cap}MetainfoResponse"
+                                    }
+                                }
+                            },
+                        },
+                        "400": {"description": "Bad Request"},
+                        "500": {"description": "Server Error"},
                     },
                 }
             }
@@ -115,6 +137,9 @@ class OpenAPIGenerator:
                         "items": {"$ref": f"#/components/schemas/{cap}Fields"},
                     }
                 },
+            }
+            openapi["components"]["schemas"][f"{cap}MetainfoResponse"] = {
+                "type": "object"
             }
 
         output.parent.mkdir(parents=True, exist_ok=True)

--- a/src/utils/infer.py
+++ b/src/utils/infer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pandas as pd
+from datetime import datetime
 
 
 def infer_type(value: pd.Series | str | int | float | bool | None) -> str:
@@ -16,8 +17,21 @@ def infer_type(value: pd.Series | str | int | float | bool | None) -> str:
     if isinstance(value, str) and value.lower() in {"true", "false"}:
         return "boolean"
 
+    if isinstance(value, str):
+        try:
+            datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return "string"
+        except ValueError:
+            pass
+
+    if isinstance(value, int) or (isinstance(value, str) and value.isdigit()):
+        return "integer"
+
     try:
-        float(str(value))
-        return "number"
+        num = float(str(value))
     except (ValueError, TypeError):
         return "string"
+
+    if num.is_integer():
+        return "integer"
+    return "number"

--- a/src/utils/payload.py
+++ b/src/utils/payload.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+
+def build_scan_payload(
+    symbols: Iterable[str], columns: Iterable[str]
+) -> Dict[str, Any]:
+    """Return a scan payload for the given symbols and columns."""
+    return {
+        "symbols": {"tickers": list(symbols), "query": {"types": []}},
+        "columns": list(columns),
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,10 @@ def _create_field_status(path: Path) -> None:
 def test_cli_scan(tv_api_mock) -> None:
     runner = CliRunner()
     tv_api_mock.post("https://scanner.tradingview.com/crypto/scan", json={"data": []})
-    result = runner.invoke(cli, ["scan", "--market", "crypto"])
+    result = runner.invoke(
+        cli,
+        ["scan", "--market", "crypto", "--symbols", "BTCUSD", "--columns", "close"],
+    )
     assert result.exit_code == 0
     assert "data" in result.output
 
@@ -42,6 +45,17 @@ def test_cli_price(tv_api_mock) -> None:
     result = runner.invoke(cli, ["price", "--symbol", "AAPL"])
     assert result.exit_code == 0
     assert "1.0" in result.output
+
+
+def test_cli_metainfo(tv_api_mock) -> None:
+    runner = CliRunner()
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/crypto/metainfo",
+        json={"fields": []},
+    )
+    result = runner.invoke(cli, ["metainfo", "--market", "crypto"])
+    assert result.exit_code == 0
+    assert "fields" in result.output
 
 
 def test_cli_help() -> None:
@@ -126,6 +140,17 @@ def test_cli_price_error(tv_api_mock) -> None:
     result = runner.invoke(cli, ["price", "--symbol", "AAPL"])
     assert result.exit_code != 0
     assert "unavailable" in result.output
+
+
+def test_cli_metainfo_error(tv_api_mock) -> None:
+    runner = CliRunner()
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/crypto/metainfo",
+        status_code=500,
+    )
+    result = runner.invoke(cli, ["metainfo", "--market", "crypto"])
+    assert result.exit_code != 0
+    assert "500" in result.output
 
 
 def test_cli_validate_missing_file() -> None:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -2,8 +2,9 @@ from src.utils.infer import infer_type
 
 
 def test_infer_type_number():
-    assert infer_type(1) == "number"
-    assert infer_type("10") == "number"
+    assert infer_type(1) == "integer"
+    assert infer_type("10") == "integer"
+    assert infer_type(1.5) == "number"
 
 
 def test_infer_type_string():
@@ -12,6 +13,11 @@ def test_infer_type_string():
 
 def test_infer_type_nan():
     assert infer_type(None) == "string"
+
+
+def test_infer_type_date():
+    assert infer_type("2023-01-01") == "string"
+    assert infer_type("2023-01-01T00:00:00Z") == "string"
 
 
 def test_infer_type_boolean():

--- a/tests/test_openapi_generator.py
+++ b/tests/test_openapi_generator.py
@@ -47,3 +47,18 @@ def test_generate_missing_field_status(tmp_path: Path) -> None:
 
     data = yaml.safe_load(out.read_text())
     assert "/crypto/scan" not in data["paths"]
+
+
+def test_generate_multiple_markets(tmp_path: Path) -> None:
+    crypto_dir = tmp_path / "results" / "crypto"
+    stocks_dir = tmp_path / "results" / "stocks"
+    _create_field_status(crypto_dir / "field_status.tsv")
+    _create_field_status(stocks_dir / "field_status.tsv")
+
+    gen = OpenAPIGenerator(tmp_path / "results")
+    out = tmp_path / "spec.yaml"
+    gen.generate(out)
+
+    data = yaml.safe_load(out.read_text())
+    assert "/crypto/scan" in data["paths"]
+    assert "/stocks/scan" in data["paths"]

--- a/tests/test_tradingview_api.py
+++ b/tests/test_tradingview_api.py
@@ -25,3 +25,13 @@ def test_scan_error(tv_api_mock):
     api = TradingViewAPI()
     with pytest.raises(Exception):
         api.scan("crypto", {})
+
+
+def test_metainfo_error(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/crypto/metainfo",
+        status_code=404,
+    )
+    api = TradingViewAPI()
+    with pytest.raises(Exception):
+        api.metainfo("crypto")


### PR DESCRIPTION
## Summary
- extend `scan` command with ticker and column options
- add new `metainfo` CLI command
- share payload builder utility
- refine type inference for integers and dates
- expand OpenAPI generator with `/metainfo` paths and standard responses
- update docs, CI workflow, changelog and version
- configure pre-commit and add tests for new functionality

## Testing
- `black --check .`
- `flake8 .`
- `mypy --strict src/`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `openapi-spec-validator specs/openapi_crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684808d3529c832c8a9db1164829fa28