### PR TITLE
Improve spec update workflow

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,23 +21,29 @@ jobs:
         uses: rhysd/actionlint@v1.7.7
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install requests_mock yamllint
           pip install -e .
-      - name: Generate spec
-        run: tvgen generate --market crypto --output specs/openapi_crypto.yaml
-      - name: Validate spec
+      - name: Generate specs for all markets
         run: |
-          yamllint specs/openapi_crypto.yaml
-          openapi-spec-validator specs/openapi_crypto.yaml
+          for market in crypto forex stocks futures; do
+            tvgen generate --market $market --output specs/openapi_${market}.yaml
+          done
+      - name: Validate all generated specs
+        run: |
+          for spec in specs/openapi_*.yaml; do
+            yamllint "$spec"
+            openapi-spec-validator "$spec"
+          done
       - name: Commit changes
         uses: EndBug/add-and-commit@v9
         with:
-          add: specs/openapi_crypto.yaml
+          add: specs/openapi_*.yaml
           message: 'chore: update generated specifications'
           default_author: github_actions
       - name: Create Pull Request
@@ -44,3 +53,8 @@ jobs:
           title: 'Update OpenAPI specifications'
           body: 'Automated update of generated specifications.'
           branch: 'auto/spec-update'
+      - name: Notify on failure
+        if: failure()
+        uses: actions/notify-slack@v3
+        with:
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary
- run CI on multiple Python versions with caching
- generate and validate specs for crypto, forex, stocks and futures
- add Slack notifications on workflow failure

## Testing
- `black .`
- `flake8 .`
- `mypy src`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684831a2a5d0832ca9b1feea1f9fa264