### PR TITLE
Fix workflow slack action version

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -55,6 +55,6 @@ jobs:
           branch: 'auto/spec-update'
       - name: Notify on failure
         if: failure()
-        uses: actions/notify-slack@v3
+        uses: actions/notify-slack@v2
         with:
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary
- use correct `actions/notify-slack` version

## Testing
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684833a2dc4c832ca7bbe7add2024a86