### PR TITLE
Fix tests and update spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.8.8
+* Fixed test linting issues and updated dependencies
+* Version bump
 ## 0.8.7
 * Refactored CLI exception handling for specific error types
 * Added logging of CLI errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
     "click",
     "requests",

--- a/specs/openapi_crypto.yaml
+++ b/specs/openapi_crypto.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Unofficial TradingView Scanner API
-  version: 0.8.7
+  version: 0.8.8
   description: Auto-generated from collected field data.
 servers:
   - url: https://scanner.tradingview.com

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import click
 import yaml
 from click.testing import CliRunner
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pandas as pd
 from src.utils.infer import infer_type
 
 

--- a/tests/test_openapi_generator.py
+++ b/tests/test_openapi_generator.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pytest
 import yaml
-import toml
 from unittest import mock
 from src.generator.openapi_generator import OpenAPIGenerator
 

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -26,7 +26,15 @@ def test_build_scan_payload_filters():
 
 def test_build_scan_payload_invalid_filter_type():
     with pytest.raises(TypeError) as exc:
-        build_scan_payload(["A"], ["close"], ["not", "a", "dict"])  # type: ignore[arg-type]
+        build_scan_payload(
+            ["A"],
+            ["close"],
+            [  # type: ignore[arg-type]
+                "not",
+                "a",
+                "dict",
+            ],
+        )
     assert "filter must be a dict" in str(exc.value)
 
 


### PR DESCRIPTION
## Summary
- clean up unused imports in tests
- fix line length in payload tests
- bump version to 0.8.8 and regenerate spec

## Testing
- `python -m codex_actions format_code`
- `python -m codex_actions generate_openapi_spec`
- `python -m codex_actions validate_spec`
- `python -m codex_actions run_tests`

------
https://chatgpt.com/codex/tasks/task_e_6848ca9dc130832c875fd8e4231831b0