### PR TITLE
Fix spec update permissions

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- allow spec-update workflow to push by granting write access

Make sure to add a `SLACK_WEBHOOK` secret in repo settings if you want Slack notifications.

## Testing
- `python - <<'PY'
import codex_actions as c
c.generate_openapi_spec()
c.validate_spec()
c.run_tests()
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6848cde10b28832cb1c143d3e318fda6