### PR TITLE
Fix spec update workflow

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -42,22 +42,26 @@ jobs:
             yamllint "$spec"
             openapi-spec-validator "$spec"
           done
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: specs/openapi_*.yaml
-          message: 'chore: update generated specifications'
-          default_author: github_actions
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: 'chore: update generated specifications'
-          title: 'Update OpenAPI specifications'
-          body: 'Automated update of generated specifications.'
-          branch: 'auto/spec-update'
-      - name: Notify on failure
-        if: failure()
-        uses: Ilshidur/action-slack@2.1.0
-        with:
-          webhook_url: ${{ secrets.SLACK_WEBHOOK }}
-          msg: 'Workflow failed: ${{ github.workflow }} in ${{ github.repository }}'
+        - name: Commit changes
+          uses: EndBug/add-and-commit@v9
+          with:
+            add: specs/openapi_*.yaml
+            message: 'chore: update generated specifications'
+            default_author: github_actions
+        - name: Fetch and rebase before push
+          run: |
+            git fetch origin main
+            git rebase origin/main
+        - name: Create Pull Request
+          uses: peter-evans/create-pull-request@v7
+          with:
+            commit-message: 'chore: update generated specifications'
+            title: 'Update OpenAPI specifications'
+            body: 'Automated update of generated specifications.'
+            branch: 'auto/spec-update'
+        # - name: Notify on failure
+        #   if: failure()
+        #   uses: Ilshidur/action-slack@2.1.0
+        #   with:
+        #     webhook_url: ${{ secrets.SLACK_WEBHOOK }}
+        #     msg: 'Workflow failed: ${{ github.workflow }} in ${{ github.repository }}'


### PR DESCRIPTION
## Summary
- ensure openapi spec update step fetches and rebases before pushing
- disable Slack failure notification in spec workflow

## Testing
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`
- `pytest -q`
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_6848d0b787c0832c871dce9362701f5c