### PR TITLE
Fix CLI flags and extend tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,15 +8,21 @@
   * `generator/` — OpenAPI 3.1.0 spec generation logic
   * `utils/` — shared utilities and type inference
 * CLI interface: `src/cli.py`
-  * `tvgen scan --market <market>` - perform a basic scan
+  * `tvgen scan --scope <market>` - perform a basic scan
   * `tvgen recommend --symbol <symbol> [--market stocks]` - fetch recommendation
   * `tvgen price --symbol <symbol> [--market stocks]` - fetch last close price
+  * `tvgen search --payload <json> --scope <market>` - call /{scope}/search
+  * `tvgen history --payload <json> --scope <market>` - call /{scope}/history
   * `tvgen summary --payload <json> --scope <market>` - call /{scope}/summary
   * `tvgen generate --market <market> --output specs/<market>.yaml` - create spec
   * `tvgen validate --spec <file>` - validate a spec file
 * Tests: `tests/`
 * OpenAPI specs: `specs/`
-* Legacy scripts (deprecated) live in the project root and must be removed
+
+Common flags:
+
+* `--scope` - TradingView market name for scan-like commands
+* `--filter2`, `--sort`, `--range` - optional JSON objects passed to `scan`
 
 ---
 
@@ -111,3 +117,6 @@ A nightly or weekly scheduled job can re-run the same steps to keep specs up-to-
 * `validate_spec()`
 * `bump_version()`
 * `create_pull_request()`
+
+`bump_version()` updates `pyproject.toml` and `CHANGELOG.md`. `create_pull_request()`
+uses the GitHub CLI to open a PR with updated specs.

--- a/README.md
+++ b/README.md
@@ -35,13 +35,21 @@ pre-commit install
 Scan a market:
 
 ```bash
-tvgen scan --market crypto --symbols BTCUSD --columns close
+tvgen scan --scope crypto --symbols BTCUSD --columns close
+```
+
+Additional scan options are available:
+
+```bash
+tvgen scan --scope crypto \
+  --symbols BTCUSD --columns close \
+  --filter "{}" --filter2 "{}" --sort "{}" --range "{}"
 ```
 
 Fetch market metadata:
 
 ```bash
-tvgen metainfo --market crypto
+tvgen metainfo --scope crypto --query btc
 ```
 
 Generate an OpenAPI spec and save it to `specs/`:
@@ -66,7 +74,7 @@ tvgen price --symbol AAPL
 Set `TV_CACHE=1` to cache HTTP responses locally:
 
 ```bash
-TV_CACHE=1 tvgen scan --market crypto --symbols BTCUSD --columns close
+TV_CACHE=1 tvgen scan --scope crypto --symbols BTCUSD --columns close
 ```
 
 ## Tests

--- a/codex_actions.py
+++ b/codex_actions.py
@@ -33,8 +33,44 @@ def format_code():
 
 
 def bump_version():
-    raise NotImplementedError("Version bump must be done manually")
+    """Bump patch version in pyproject.toml and update CHANGELOG."""
+    import toml
+    from pathlib import Path
+
+    pyproject = Path("pyproject.toml")
+    data = toml.load(pyproject)
+    version = data["project"]["version"]
+    major, minor, patch = map(int, version.split("."))
+    new_version = f"{major}.{minor}.{patch + 1}"
+    data["project"]["version"] = new_version
+    with open(pyproject, "w", encoding="utf-8") as fh:
+        toml.dump(data, fh)
+
+    changelog = Path("CHANGELOG.md")
+    if changelog.exists():
+        lines = changelog.read_text().splitlines()
+    else:
+        lines = ["# Changelog"]
+    header = f"## {new_version}"
+    entry = "- Version bump"
+    if header not in lines:
+        lines.insert(1, header)
+        lines.insert(2, entry)
+    changelog.write_text("\n".join(lines) + "\n")
+    print(f"Version bumped to {new_version}")
 
 
 def create_pull_request():
-    raise NotImplementedError("PR creation is handled externally")
+    """Open a pull request using the GitHub CLI."""
+    subprocess.run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--title",
+            "Update OpenAPI specs",
+            "--body",
+            "Automated specification update",
+        ],
+        check=True,
+    )

--- a/src/api/tradingview_api.py
+++ b/src/api/tradingview_api.py
@@ -68,9 +68,10 @@ class TradingViewAPI:
         }
 
     def _request(
-        self, method: str, url: str, payload: Dict[str, Any]
+        self, scope: str, endpoint: str, method: str, payload: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Internal helper to send a request and parse JSON."""
+        url = self._url(scope, endpoint)
         logger.debug("%s %s", method.upper(), url)
         try:
             r = self.session.request(method, url, json=payload, timeout=self.timeout)
@@ -98,25 +99,20 @@ class TradingViewAPI:
 
     def scan(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Send GET /{scope}/scan and return JSON."""
-        url = self._url(scope, "scan")
-        return self._request("GET", url, payload)
+        return self._request(scope, "scan", "GET", payload)
 
     def metainfo(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Fetch metainfo for scope."""
-        url = self._url(scope, "metainfo")
-        return self._request("POST", url, payload)
+        return self._request(scope, "metainfo", "POST", payload)
 
     def search(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         """POST /{scope}/search."""
-        url = self._url(scope, "search")
-        return self._request("POST", url, payload)
+        return self._request(scope, "search", "POST", payload)
 
     def history(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         """POST /{scope}/history."""
-        url = self._url(scope, "history")
-        return self._request("POST", url, payload)
+        return self._request(scope, "history", "POST", payload)
 
     def summary(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         """POST /{scope}/summary."""
-        url = self._url(scope, "summary")
-        return self._request("POST", url, payload)
+        return self._request(scope, "summary", "POST", payload)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,36 @@ def test_cli_scan(tv_api_mock) -> None:
     assert "data" in result.output
 
 
+def test_cli_scan_full_payload(tv_api_mock) -> None:
+    runner = CliRunner()
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/crypto/scan",
+        json={"data": []},
+    )
+    payload_args = [
+        "scan",
+        "--symbols",
+        "BTCUSD",
+        "--columns",
+        "close",
+        "--scope",
+        "crypto",
+        "--filter2",
+        "{}",
+        "--sort",
+        "{}",
+        "--range",
+        "{}",
+    ]
+    result = runner.invoke(cli, payload_args)
+    assert result.exit_code == 0
+    assert "data" in result.output
+    sent = tv_api_mock.request_history[0].json()
+    assert sent["filter2"] == {}
+    assert sent["sort"] == {}
+    assert sent["range"] == {}
+
+
 def test_cli_recommend(tv_api_mock) -> None:
     runner = CliRunner()
     tv_api_mock.get(

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -32,11 +32,14 @@ def test_infer_type_nan_value():
 def test_infer_type_series_none_only():
     series = pd.Series([None, None])
     assert infer_type(series) == "string"
+    assert infer_type(pd.Series([pd.NA, None])) == "string"
+    assert infer_type(pd.Series([])) == "string"
 
 
 def test_infer_type_date():
     assert infer_type("2023-01-01") == "string"
     assert infer_type("2023-01-01T00:00:00Z") == "string"
+    assert infer_type("2023-01-01T00:00:00+03:00") == "string"
 
 
 def test_infer_type_boolean():

--- a/tests/test_openapi_generator.py
+++ b/tests/test_openapi_generator.py
@@ -40,7 +40,9 @@ def test_generate(tmp_path: Path):
     assert "CryptoScanRequest" in schemas
     assert "CryptoScanResponse" in schemas
     assert "CryptoMetainfoResponse" in schemas
-    assert "filter" in schemas["CryptoScanRequest"]["properties"]
+    props = schemas["CryptoScanRequest"]["properties"]
+    for name in ["filter", "filter2", "sort", "range"]:
+        assert name in props
     # new endpoints
     for ep in ["search", "history", "summary"]:
         assert f"/crypto/{ep}" in data["paths"]

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -38,6 +38,21 @@ def test_build_scan_payload_invalid_filter_type():
     assert "filter must be a dict" in str(exc.value)
 
 
+@pytest.mark.parametrize(
+    "kw,value,msg",
+    [
+        ("filter2", [], "filter2 must be a dict"),
+        ("sort", [], "sort must be a dict"),
+        ("range_", [], "range must be a dict"),
+    ],
+)
+def test_build_scan_payload_invalid_types(kw, value, msg):
+    kwargs = {kw: value}  # type: ignore[arg-type]
+    with pytest.raises(TypeError) as exc:
+        build_scan_payload(["A"], ["close"], **kwargs)
+    assert msg in str(exc.value)
+
+
 def test_build_scan_payload_empty_symbols():
     with pytest.raises(ValueError) as exc:
         build_scan_payload([], ["close"])

--- a/tests/test_stock_data.py
+++ b/tests/test_stock_data.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 from src.api.stock_data import fetch_recommendation, fetch_stock_value
 
 
@@ -36,3 +37,21 @@ def test_fetch_recommendation_error(tv_api_mock):
     with pytest.raises(ValueError) as exc:
         fetch_recommendation("AAPL")
     assert "AAPL" in str(exc.value)
+
+
+def test_fetch_stock_http_error(tv_api_mock):
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/stocks/scan",
+        status_code=500,
+    )
+    with pytest.raises(requests.exceptions.HTTPError):
+        fetch_stock_value("AAPL")
+
+
+def test_fetch_recommend_http_error(tv_api_mock):
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/stocks/scan",
+        status_code=404,
+    )
+    with pytest.raises(requests.exceptions.HTTPError):
+        fetch_recommendation("AAPL")

--- a/tests/test_tradingview_api.py
+++ b/tests/test_tradingview_api.py
@@ -70,6 +70,30 @@ def test_scan_invalid_json(tv_api_mock):
         api.scan("crypto", {})
 
 
+@pytest.mark.parametrize("endpoint", ["search", "history", "summary"])
+def test_endpoint_error(tv_api_mock, endpoint):
+    tv_api_mock.post(
+        f"https://scanner.tradingview.com/crypto/{endpoint}",
+        status_code=500,
+    )
+    api = TradingViewAPI()
+    method = getattr(api, endpoint)
+    with pytest.raises(requests.exceptions.HTTPError):
+        method("crypto", {})
+
+
+@pytest.mark.parametrize("endpoint", ["search", "history", "summary"])
+def test_endpoint_invalid_json(tv_api_mock, endpoint):
+    tv_api_mock.post(
+        f"https://scanner.tradingview.com/crypto/{endpoint}",
+        text="not-json",
+    )
+    api = TradingViewAPI()
+    method = getattr(api, endpoint)
+    with pytest.raises(ValueError):
+        method("crypto", {})
+
+
 def test_metainfo_error(tv_api_mock):
     tv_api_mock.post(
         "https://scanner.tradingview.com/crypto/metainfo",


### PR DESCRIPTION
## Summary
- update README and agent docs for `--scope` flag
- document extra scan flags in AGENTS
- implement version bump and PR helper
- refactor TradingViewAPI request helper
- extend CLI and API tests
- add additional payload and inference checks

## Testing
- `black . --check`
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --market crypto --output specs/test_spec.yaml --results-dir results`
- `tvgen validate --spec specs/test_spec.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6848d3283498832cbfe85f9611f79225