### PR TITLE
Improve codex actions error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.10
+- Version bump
 ## 0.8.9
 - Fixed Slack notification action version in spec update workflow
 - Version bump

--- a/codex_actions.py
+++ b/codex_actions.py
@@ -1,35 +1,64 @@
 import subprocess
+import sys
 
 
 def generate_openapi_spec():
     """Run the CLI generator for the crypto market."""
-    subprocess.run(
-        [
-            "tvgen",
-            "generate",
-            "--market",
-            "crypto",
-            "--output",
-            "specs/openapi_crypto.yaml",
-        ],
-        check=True,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "tvgen",
+                "generate",
+                "--market",
+                "crypto",
+                "--output",
+                "specs/openapi_crypto.yaml",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        if result.stdout:
+            print(result.stdout)
+    except FileNotFoundError:
+        print("tvgen command not found", file=sys.stderr)
+        raise
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr, file=sys.stderr)
+        raise
 
 
 def validate_spec():
     """Validate the generated crypto specification."""
-    subprocess.run(
-        ["tvgen", "validate", "--spec", "specs/openapi_crypto.yaml"],
-        check=True,
-    )
+    try:
+        subprocess.run(
+            ["tvgen", "validate", "--spec", "specs/openapi_crypto.yaml"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("tvgen command not found", file=sys.stderr)
+        raise
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr, file=sys.stderr)
+        raise
 
 
 def run_tests():
-    subprocess.run(["pytest", "-q"], check=True)
+    try:
+        subprocess.run(["pytest", "-q"], check=True)
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr, file=sys.stderr)
+        raise
 
 
 def format_code():
-    subprocess.run(["black", "."], check=True)
+    try:
+        subprocess.run(["black", "."], check=True)
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr, file=sys.stderr)
+        raise
 
 
 def bump_version():
@@ -62,15 +91,22 @@ def bump_version():
 
 def create_pull_request():
     """Open a pull request using the GitHub CLI."""
-    subprocess.run(
-        [
-            "gh",
-            "pr",
-            "create",
-            "--title",
-            "Update OpenAPI specs",
-            "--body",
-            "Automated specification update",
-        ],
-        check=True,
-    )
+    try:
+        subprocess.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--title",
+                "Update OpenAPI specs",
+                "--body",
+                "Automated specification update",
+            ],
+            check=True,
+        )
+    except FileNotFoundError:
+        print("GitHub CLI not found", file=sys.stderr)
+        raise
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr, file=sys.stderr)
+        raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,29 +1,20 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = [ "setuptools", "wheel",]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.9"
-dependencies = [
-    "click",
-    "requests",
-    "pandas",
-    "PyYAML",
-    "openapi-spec-validator",
-    "toml",
-    "requests_cache",
-]
+version = "0.8.10"
+dependencies = [ "click", "requests", "pandas", "PyYAML", "openapi-spec-validator", "toml", "requests_cache",]
 
 [project.scripts]
 tvgen = "src.cli:cli"
 
 [tool.setuptools]
-packages = ["src", "src.api", "src.generator", "src.utils"]
-
-[tool.setuptools.package-dir]
-src = "src"
+packages = [ "src", "src.api", "src.generator", "src.utils",]
 
 [tool.mypy]
 ignore_missing_imports = true
-ignore_errors = true
+
+[tool.setuptools.package-dir]
+src = "src"

--- a/specs/openapi_crypto.yaml
+++ b/specs/openapi_crypto.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Unofficial TradingView Scanner API
-  version: 0.8.9
+  version: 0.8.10
   description: Auto-generated from collected field data.
 servers:
   - url: https://scanner.tradingview.com
@@ -111,7 +111,7 @@ components:
         close:
           type: integer
         open:
-          type: string
+          type: integer
     CryptoScanRequest:
       type: object
       properties:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -55,3 +55,9 @@ def test_infer_type_series_mixed():
 
     series2 = pd.Series([1, "a"])
     assert infer_type(series2) == "string"
+
+
+def test_infer_type_large_numbers():
+    assert infer_type(10**12) == "integer"
+    assert infer_type("1e10") == "number"
+    assert infer_type(1e-5) == "number"


### PR DESCRIPTION
## Summary
- handle subprocess errors in `codex_actions.py`
- remove `ignore_errors` from mypy config
- bump version to 0.8.10
- add tests for large number inference
- regenerate crypto spec

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -e .`
- `python - <<'PY'
import codex_actions as ca
ca.run_tests()
PY`
- `python - <<'PY'
import codex_actions as ca
ca.generate_openapi_spec()
PY`
- `python - <<'PY'
import codex_actions as ca
ca.validate_spec()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68496a301904832c8181296f70da7da2