### PR TITLE
Fix version info and regenerate specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.14
+- Version bump
 ## 0.8.13
 - Version bump
 ## 0.8.12

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tv-generator
 
-[![CI](https://github.com/your-org/tv-generator/actions/workflows/ci.yml/badge.svg)](https://github.com/your-org/tv-generator/actions/workflows/ci.yml)
+[![CI](https://github.com/TrololoBird/tv-generator/actions/workflows/ci.yml/badge.svg)](https://github.com/TrololoBird/tv-generator/actions/workflows/ci.yml)
 
 Utilities for interacting with the TradingView Screener API and generating an OpenAPI specification.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
+version = "0.8.14"
 dependencies = [ "click", "requests", "pandas", "PyYAML", "openapi-spec-validator", "toml", "requests_cache",]
 
 [project.scripts]

--- a/specs/openapi_crypto.yaml
+++ b/specs/openapi_crypto.yaml
@@ -1,6 +1,7 @@
 openapi: 3.1.0
 info:
   title: Unofficial TradingView Scanner API
+  version: 0.8.14
   description: Auto-generated from collected field data.
 servers:
   - url: https://scanner.tradingview.com
@@ -107,10 +108,10 @@ components:
     CryptoFields:
       type: object
       properties:
-        foo:
+        close:
           type: integer
         open:
-          type: integer
+          type: string
     CryptoScanRequest:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- restore missing version metadata in `pyproject.toml`
- update CI badge link
- bump version and changelog
- regenerate crypto OpenAPI spec

## Testing
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`
- `pytest -q`
- `black .`


------
https://chatgpt.com/codex/tasks/task_e_684979c93204832c88bc8bd33b4c2ea6