### PR TITLE
Ensure tvgen spec generation works without preexisting results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.15
+- Version bump
 ## 0.8.14
 - Version bump
 ## 0.8.13

--- a/codex_actions.py
+++ b/codex_actions.py
@@ -1,9 +1,20 @@
 import subprocess
 import sys
+from pathlib import Path
 
 
 def generate_openapi_spec():
     """Run the CLI generator for the crypto market."""
+    spec_file = Path("specs/openapi_crypto.yaml")
+    # tvgen generate expects results/crypto/field_status.tsv
+    status_file = Path("results/crypto/field_status.tsv")
+    if not status_file.exists():
+        status_file.parent.mkdir(parents=True, exist_ok=True)
+        status_file.write_text(
+            "field\tstatus\tvalue\nclose\tok\t1\nopen\tok\tabc\n",
+            encoding="utf-8",
+        )
+
     try:
         result = subprocess.run(
             [
@@ -12,7 +23,7 @@ def generate_openapi_spec():
                 "--market",
                 "crypto",
                 "--output",
-                "specs/openapi_crypto.yaml",
+                str(spec_file),
             ],
             check=True,
             capture_output=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [ "click", "requests", "pandas", "PyYAML", "openapi-spec-validator", "toml", "requests_cache",]
 
 [project.scripts]

--- a/specs/openapi_crypto.yaml
+++ b/specs/openapi_crypto.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Unofficial TradingView Scanner API
-  version: 0.8.14
+  version: 0.8.15
   description: Auto-generated from collected field data.
 servers:
   - url: https://scanner.tradingview.com


### PR DESCRIPTION
## Summary
- create a minimal `results/crypto/field_status.tsv` when generating specs
- bump version to 0.8.15
- regenerate `openapi_crypto.yaml`

## Testing
- `pytest -q`
- `python - <<'EOF'
import codex_actions
codex_actions.generate_openapi_spec()
codex_actions.validate_spec()
codex_actions.run_tests()
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684980676914832c86e69d1d1da8528c