### PR TITLE
Fix spec update workflow to always create PR

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -49,19 +49,14 @@ jobs:
             yamllint "$spec"
             openapi-spec-validator "$spec"
           done
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: specs/openapi_*.yaml
-          message: 'chore: update generated specifications'
-          default_author: github_actions
-      - name: Fetch and rebase before push
+      - name: Fetch and rebase before PR
         run: |
           git fetch origin main
           git rebase origin/main
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
+          add-paths: 'specs/openapi_*.yaml'
           commit-message: 'chore: update generated specifications'
           title: 'Update OpenAPI specifications'
           body: 'Automated update of generated specifications.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.16
+- Version bump
 ## 0.8.15
 - Version bump
 ## 0.8.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [ "click", "requests", "pandas", "PyYAML", "openapi-spec-validator", "toml", "requests_cache",]
 
 [project.scripts]

--- a/specs/openapi_crypto.yaml
+++ b/specs/openapi_crypto.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Unofficial TradingView Scanner API
-  version: 0.8.15
+  version: 0.8.16
   description: Auto-generated from collected field data.
 servers:
   - url: https://scanner.tradingview.com


### PR DESCRIPTION
## Summary
- bump version to 0.8.16
- update spec-update workflow to create a PR instead of pushing directly
- regenerate crypto spec

## Testing
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `openapi-spec-validator specs/openapi_crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684991b1a8ec832cbe31c23a26d87f16