### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,16 @@ jobs:
         run: mypy --strict src/
       - name: Test
         run: pytest -q
-      - name: Generate spec
+      - name: Generate specs for all markets
         run: |
-          mkdir -p results/crypto
-          echo -e "field\tstatus\tvalue\nclose\tok\t1\nopen\tok\tabc" > results/crypto/field_status.tsv
-          tvgen generate --market crypto --output specs/openapi_crypto.yaml
-      - name: Validate OpenAPI
-        run: openapi-spec-validator specs/openapi_crypto.yaml
+          for market in crypto forex stocks futures; do
+            mkdir -p results/$market
+            echo -e "field\tstatus\tvalue\nclose\tok\t1\nopen\tok\tabc" > results/$market/field_status.tsv
+            tvgen generate --market $market --output specs/openapi_${market}.yaml
+          done
+
+      - name: Validate all generated specs
+        run: |
+          for spec in specs/openapi_*.yaml; do
+            openapi-spec-validator "$spec"
+          done

--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install requests_mock yamllint \
+          pip install requests_mock yamllint openapi-spec-validator \
             types-requests types-PyYAML types-toml
           pip install -e .
       - name: Prepare field status files
@@ -49,14 +49,20 @@ jobs:
             yamllint "$spec"
             openapi-spec-validator "$spec"
           done
-      - name: Fetch and rebase before PR
+      - name: Fetch and rebase before commit
         run: |
           git fetch origin main
           git rebase origin/main
+
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: specs/openapi_*.yaml
+          message: 'chore: update generated specifications'
+          default_author: github_actions
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          add-paths: 'specs/openapi_*.yaml'
           commit-message: 'chore: update generated specifications'
           title: 'Update OpenAPI specifications'
           body: 'Automated update of generated specifications.'


### PR DESCRIPTION
## Summary
- install `openapi-spec-validator` for spec updates
- ensure spec update workflow commits with add-and-commit
- rebase before committing updates
- generate and validate specs for all markets in CI

## Testing
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684992ecc290832caa7d206930698cba