### PR TITLE
Fix spec-update workflow rebase failure

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -49,10 +49,19 @@ jobs:
             yamllint "$spec"
             openapi-spec-validator "$spec"
           done
+      - name: Stash changes (if any)
+        run: |
+          git stash --include-untracked
+
       - name: Fetch and rebase before commit
         run: |
           git fetch origin main
           git rebase origin/main
+
+      - name: Apply stashed changes (if stashed)
+        if: success() && run.output contains 'No local changes to save'
+        run: |
+          git stash pop || echo "No stashed changes to apply"
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
## Summary
- update spec-update workflow to stash changes before rebasing

## Testing
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684999c136f0832cb91a133bb5a3dfff