### PR TITLE
Fix workflow permissions

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     permissions:
       contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- allow creating pull requests from the spec-update workflow

## Testing
- `python - <<'PY'
from codex_actions import generate_openapi_spec, validate_spec, run_tests, format_code
format_code()
generate_openapi_spec()
validate_spec()
run_tests()
PY`

------
https://chatgpt.com/codex/tasks/task_e_6849a32797ac832c8d9b4af8ba19b8a1