### PR TITLE
Fix spec update workflow permissions

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  pull-requests: write
+
 jobs:
   build:
     permissions:


### PR DESCRIPTION
## Summary
- allow GitHub Actions to create pull requests in the spec update workflow

## Testing
- `python - <<'PY'
import codex_actions as ca
ca.generate_openapi_spec()
ca.validate_spec()
ca.run_tests()
PY`

------
https://chatgpt.com/codex/tasks/task_e_6849a4ddcd84832cb2d5fbf7718096d8