### PR TITLE
Fix spec-update permissions

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -8,6 +8,7 @@ on:
     - cron: '0 2 * * *'
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:
@@ -79,6 +80,7 @@ jobs:
           title: 'Update OpenAPI specifications'
           body: 'Automated update of generated specifications.'
           branch: 'auto/spec-update'
+          token: ${{ secrets.GITHUB_TOKEN }}
         # - name: Notify on failure
         #   if: failure()
         #   uses: Ilshidur/action-slack@2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.17
+- Version bump
 ## 0.8.16
 - Version bump
 ## 0.8.15

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ openapi-spec-validator specs/openapi_crypto.yaml
 ### Automated spec updates
 
 The [`spec-update.yml`](.github/workflows/spec-update.yml) workflow runs weekly to generate and validate the OpenAPI spec. If the specification file changes, a pull request is opened automatically with the updated YAML.
+Ensure the repository grants **Read and write permissions** and enables **Allow GitHub Actions to create and approve pull requests** so the workflow can open pull requests.
 ## Troubleshooting CI failures
 
 Most CI issues are caused by formatting, lint or type errors. Before pushing run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.16"
+version = "0.8.17"
 dependencies = [ "click", "requests", "pandas", "PyYAML", "openapi-spec-validator", "toml", "requests_cache",]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- allow spec-update to push and create PRs
- add note about permissions in README
- bump version to 0.8.17

## Testing
- `tvgen validate --spec specs/openapi_crypto.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849a654a7d8832c9bf31458e69a6176