### PR TITLE
Fix spec update workflow branch

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -58,11 +58,6 @@ jobs:
         run: |
           git stash --include-untracked
 
-      - name: Fetch and rebase before commit
-        run: |
-          git fetch origin main
-          git rebase origin/main
-
       - name: Apply stashed changes
         run: |
           git stash pop || echo "No stashed changes to apply"
@@ -79,7 +74,7 @@ jobs:
           commit-message: 'chore: update generated specifications'
           title: 'Update OpenAPI specifications'
           body: 'Automated update of generated specifications.'
-          branch: 'auto/spec-update'
+          branch: 'OpenAPI'
           token: ${{ secrets.GITHUB_TOKEN }}
         # - name: Notify on failure
         #   if: failure()


### PR DESCRIPTION
## Summary
- avoid rebasing on `main` in the spec update workflow
- create PRs from the `OpenAPI` branch

## Testing
- `python - <<'PY'
import codex_actions as c
c.generate_openapi_spec()
c.validate_spec()
PY
`
- `python - <<'PY'
import codex_actions as c
c.run_tests()
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6849ab23bcac832c8f0eda097f9a79e9