### PR TITLE
Fix PR creation token

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -75,7 +75,7 @@ jobs:
           title: 'Update OpenAPI specifications'
           body: 'Automated update of generated specifications.'
           branch: 'OpenAPI'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         # - name: Notify on failure
         #   if: failure()
         #   uses: Ilshidur/action-slack@2.1.0


### PR DESCRIPTION
## Summary
- use `PERSONAL_ACCESS_TOKEN` when opening auto-generated spec PRs

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6849cf673e6c832c86f2c80d360fbe32