### PR TITLE
Fix workflow token

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -75,7 +75,7 @@ jobs:
           title: 'Update OpenAPI specifications'
           body: 'Automated update of generated specifications.'
           branch: 'OpenAPI'
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
         # - name: Notify on failure
         #   if: failure()
         #   uses: Ilshidur/action-slack@2.1.0


### PR DESCRIPTION
## Summary
- use the built-in `GITHUB_TOKEN` to create spec PRs

## Testing
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`
- `pytest -q`
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_6849d4e3a7d8832c8ef235dfa0e9a81c