### PR TITLE
Fix workflow syntax

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -1,5 +1,6 @@
-name: Update Specs
+---
 # yamllint disable rule:truthy rule:line-length
+name: Update Specs
 
 on:
   workflow_dispatch: {}  # yamllint disable-line rule:truthy
@@ -67,17 +68,18 @@ jobs:
           add: specs/openapi_*.yaml
           message: 'chore: update generated specifications'
           default_author: github_actions
-- name: Create Pull Request
-  uses: peter-evans/create-pull-request@v7
-  with:
-    commit-message: 'chore: update generated specifications'
-    title: 'Update OpenAPI specifications'
-    body: 'Automated update of generated specifications.'
-    branch: 'OpenAPI'
-    token: ${{ secrets.PAT_TOKEN }}
-        # - name: Notify on failure
-        #   if: failure()
-        #   uses: Ilshidur/action-slack@2.1.0
-        #   with:
-        #     webhook_url: ${{ secrets.SLACK_WEBHOOK }}
-        #     msg: 'Workflow failed: ${{ github.workflow }} in ${{ github.repository }}'
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: 'chore: update generated specifications'
+          title: 'Update OpenAPI specifications'
+          body: 'Automated update of generated specifications.'
+          branch: 'OpenAPI'
+          token: ${{ secrets.PAT_TOKEN }}
+          # - name: Notify on failure
+          #   if: failure()
+          #   uses: Ilshidur/action-slack@2.1.0
+          #   with:
+          #     webhook_url: ${{ secrets.SLACK_WEBHOOK }}
+          #     msg: 'Workflow failed: ${{ github.workflow }} in ${{ github.repository }}'


### PR DESCRIPTION
## Summary
- fix indentation and document start in `spec-update.yml`

## Testing
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`
- `pytest -q`
- `yamllint .github/workflows/spec-update.yml`
- `actionlint .github/workflows/spec-update.yml`

------
https://chatgpt.com/codex/tasks/task_e_6849e891edf4832cbd2b1a8f22c624de