### PR TITLE
Fix PAT_TOKEN usage

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -76,7 +76,7 @@ jobs:
           title: 'Update OpenAPI specifications'
           body: 'Automated update of generated specifications.'
           branch: 'OpenAPI'
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           # - name: Notify on failure
           #   if: failure()
           #   uses: Ilshidur/action-slack@2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.20
+- Version bump
 ## 0.8.19
 - Version bump
 ## 0.8.18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2",]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- use `${{ secrets.GITHUB_TOKEN }}` when creating the pull request in spec update workflow
- bump version
- update changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849f268092c832c8ce33de6191f354f