### PR TITLE
Fix spec update workflow merge

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -62,6 +62,11 @@ jobs:
         run: |
           git stash pop || echo "No stashed changes to apply"
 
+      - name: Pull latest changes from remote
+        run: |
+          git fetch origin main
+          git merge origin/main
+
       - name: Commit changes
         uses: EndBug/add-and-commit@v9
         with:


### PR DESCRIPTION
## Summary
- ensure the spec update workflow merges the latest `main` branch before committing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849f780e6a4832c913e7fb1d15d341e