### PR TITLE
Update spec update workflow

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -5,7 +5,7 @@ name: Update Specs
 on:
   workflow_dispatch: {}  # yamllint disable-line rule:truthy
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 3 * * *'
 
 permissions:
   contents: write
@@ -37,16 +37,25 @@ jobs:
           pip install requests_mock yamllint openapi-spec-validator \
             types-requests types-PyYAML types-toml
           pip install -e .
-      - name: Prepare field status files
+      - name: Export server URL
+        if: ${{ secrets.SERVER_URL != '' }}
+        run: echo "SERVER_URL=${{ secrets.SERVER_URL }}" >> "$GITHUB_ENV"
+
+      - name: Collect full data
         run: |
-          for market in crypto forex stocks futures; do
-            mkdir -p "results/$market"
-            echo -e "field\tstatus\tvalue\nclose\tok\t1\nopen\tok\tabc" > "results/$market/field_status.tsv"
-          done
+          extra=""
+          if [ -n "$SERVER_URL" ]; then
+            extra="--server-url $SERVER_URL"
+          fi
+          poetry run tvgen collect-full --outdir results $extra
       - name: Generate specs for all markets
         run: |
+          extra=""
+          if [ -n "$SERVER_URL" ]; then
+            extra="--server-url $SERVER_URL"
+          fi
           for market in crypto forex stocks futures; do
-            tvgen generate --market $market --output specs/openapi_${market}.yaml  # yamllint disable-line rule:line-length
+            tvgen generate --market $market --output specs/openapi_${market}.yaml $extra  # yamllint disable-line rule:line-length
           done
       - name: Validate all generated specs
         run: |
@@ -54,6 +63,11 @@ jobs:
             yamllint "$spec"
             openapi-spec-validator "$spec"
           done
+      - name: Upload results artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: results
+          path: results/**
       - name: Stash changes (if any)
         run: |
           git stash --include-untracked
@@ -70,7 +84,9 @@ jobs:
       - name: Commit changes
         uses: EndBug/add-and-commit@v9
         with:
-          add: specs/openapi_*.yaml
+          add: |
+            specs/openapi_*.yaml
+            results/**
           message: 'chore: update generated specifications'
           default_author: github_actions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.23
+- Version bump
 ## 0.8.22
 - Version bump
 ## 0.8.21

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2",]
 
 [project.scripts]

--- a/results/crypto/field_status.tsv
+++ b/results/crypto/field_status.tsv
@@ -1,0 +1,3 @@
+field	status	value
+close	ok	1
+open	ok	abc

--- a/specs/openapi_crypto.yaml
+++ b/specs/openapi_crypto.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Unofficial TradingView Scanner API
-  version: 0.8.20
+  version: 0.8.23
   description: Auto-generated from collected field data.
 servers:
   - url: https://scanner.tradingview.com


### PR DESCRIPTION
## Summary
- tweak nightly spec update workflow
- export SERVER_URL secret and use for data collection
- collect full data and upload as artifact
- commit result & spec directories
- bump version to 0.8.23

## Testing
- `black . --check`
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/openapi_crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684a25540a9c832c89fc926a66594b39