### PR TITLE
Add tickers validation to collect-full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
-## 0.8.25
-- Version bump
+## 0.8.26
+ - Version bump
 ## 0.8.24
 - Version bump
 ## 0.8.23

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2",]
 
 [project.scripts]

--- a/src/cli.py
+++ b/src/cli.py
@@ -234,6 +234,11 @@ def collect_full(
     if not scopes:
         scopes = tuple(SCOPES)
 
+    ticker_list = [s for s in tickers.split(",") if s]
+    if not ticker_list:
+        raise click.BadParameter("No tickers", param_hint="--tickers")
+    ticker_list = ticker_list[:10]
+
     api = TradingViewAPI(base_url=server_url)
     exit_code = 0
     for scope in scopes:
@@ -261,18 +266,8 @@ def collect_full(
                     if name:
                         field_list.append((str(name), ftype))
 
-            index_obj = (
-                data_section.get("index", {}) if isinstance(data_section, dict) else {}
-            )
-            names = index_obj.get("names", []) if isinstance(index_obj, dict) else []
-            ticker_list = [s for s in tickers.split(",") if s]
-            if not ticker_list:
-                if isinstance(names, list) and names:
-                    ticker_list = [str(n) for n in names[:10]]
-                else:
-                    ticker_list = ["BTCUSD", "ETHUSD"]
             payload = {
-                "symbols": {"tickers": ticker_list[:10], "query": {"types": []}},
+                "symbols": {"tickers": ticker_list, "query": {"types": []}},
                 "columns": [f[0] for f in field_list],
             }
             scan_res = api.scan(scope, payload)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -375,7 +375,10 @@ def test_collect_full_success(tv_api_mock):
     runner = CliRunner()
     _mock_collect_api(tv_api_mock)
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["collect-full", "--scope", "crypto"])
+        result = runner.invoke(
+            cli,
+            ["collect-full", "--scope", "crypto", "--tickers", "AAA,BBB"],
+        )
         assert result.exit_code == 0
         base = Path("results/crypto")
         assert (base / "metainfo.json").exists()
@@ -390,7 +393,7 @@ def test_collect_full_alias(tv_api_mock):
     runner = CliRunner()
     _mock_collect_api(tv_api_mock)
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["collect", "--scope", "crypto"])
+        result = runner.invoke(cli, ["collect", "--scope", "crypto", "--tickers", "AAA,BBB"])
         assert result.exit_code == 0
 
 
@@ -398,7 +401,10 @@ def test_collect_full_error(tv_api_mock):
     runner = CliRunner()
     tv_api_mock.post("https://scanner.tradingview.com/crypto/metainfo", status_code=500)
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["collect-full", "--scope", "crypto"])
+        result = runner.invoke(
+            cli,
+            ["collect-full", "--scope", "crypto", "--tickers", "AAA,BBB"],
+        )
         assert result.exit_code != 0
         log = Path("results/crypto/error.log").read_text()
         assert log

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,0 +1,49 @@
+from click.testing import CliRunner
+
+from src.cli import cli
+from src.api.tradingview_api import TradingViewAPI
+
+
+def test_collect_no_tickers(monkeypatch):
+    runner = CliRunner()
+
+    def fake_meta(self, scope, payload):
+        return {"data": {"fields": [], "index": {"names": []}}}
+
+    def fake_scan(self, scope, payload):
+        return {"data": []}
+
+    monkeypatch.setattr(TradingViewAPI, "metainfo", fake_meta)
+    monkeypatch.setattr(TradingViewAPI, "scan", fake_scan)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            ["collect-full", "--scope", "crypto", "--tickers", ""],
+        )
+        assert result.exit_code == 2
+        assert "No tickers" in result.output
+
+
+def test_collect_custom_tickers(monkeypatch):
+    runner = CliRunner()
+    payload_holder = {}
+
+    def fake_meta(self, scope, payload):
+        return {"data": {"fields": [], "index": {"names": []}}}
+
+    def fake_scan(self, scope, payload):
+        payload_holder["payload"] = payload
+        return {"data": []}
+
+    monkeypatch.setattr(TradingViewAPI, "metainfo", fake_meta)
+    monkeypatch.setattr(TradingViewAPI, "scan", fake_scan)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            ["collect-full", "--scope", "crypto", "--tickers", "A,B"],
+        )
+        assert result.exit_code == 0
+        assert payload_holder["payload"]["symbols"]["tickers"] == ["A", "B"]
+


### PR DESCRIPTION
## Summary
- require `--tickers` for `collect-full`
- adjust CLI tests for new option
- add tests covering custom tickers and empty tickers
- bump version to 0.8.26

## Testing
- `python codex_actions.py format_code`
- `python codex_actions.py generate_openapi_spec`
- `python codex_actions.py validate_spec`
- `python codex_actions.py run_tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_e_684a2b5bffe8832cb0767fd9fa525659