### PR TITLE
Update docs and workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
   * `tvgen search --payload <json> --scope <market>` - call /{scope}/search
   * `tvgen history --payload <json> --scope <market>` - call /{scope}/history
   * `tvgen summary --payload <json> --scope <market>` - call /{scope}/summary
+  * `tvgen collect-full --scope <market> [--tickers ...]` - gather field data
   * `tvgen generate --market <market> --output specs/<market>.yaml` - create spec
   * `tvgen validate --spec <file>` - validate a spec file
 * Tests: `tests/`
@@ -25,6 +26,8 @@ Common flags:
 * `--filter2`, `--sort`, `--range` - optional JSON objects passed to `scan`
 
 ---
+
+**Workflow**: `tvgen collect-full` → `tvgen generate` → `tvgen validate` → commit
 
 ## 🛠 Development Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.28
+- Added full-field generation, Pydantic validation, etc.
 ## 0.8.27
 - Version bump
 ## 0.8.26

--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ Fetch market metadata:
 tvgen metainfo --scope crypto --query btc
 ```
 
-Generate an OpenAPI spec and save it to `specs/`:
+Collect full field data and generate an OpenAPI spec:
 
 ```bash
+tvgen collect-full --scope crypto --tickers BTCUSD,ETHUSD
 tvgen generate --market crypto --output specs/openapi_crypto.yaml
 ```
 
@@ -83,6 +84,8 @@ Validate a spec file:
 ```bash
 tvgen validate --spec specs/openapi_crypto.yaml
 ```
+
+This produces an updated `specs/openapi_crypto.yaml`. Commit the file after validation.
 
 Fetch recommendation or price for a symbol:
 
@@ -124,6 +127,7 @@ black --check .
 flake8 .
 mypy src/
 pytest -q
+tvgen collect-full --scope crypto
 tvgen generate --market crypto --output specs/openapi_crypto.yaml
 openapi-spec-validator specs/openapi_crypto.yaml
 ```
@@ -142,6 +146,7 @@ black .
 flake8 .
 mypy src/
 pytest -q
+tvgen collect-full --scope crypto
 tvgen generate --market crypto --output specs/openapi_crypto.yaml
 openapi-spec-validator specs/openapi_crypto.yaml
 ```
@@ -150,8 +155,9 @@ Ensure all commands succeed locally to avoid pipeline failures.
 
 ## Интеграция с GPT Builder Custom Action
 
-1. Сгенерируйте YAML спецификацию командой:
+1. Соберите все поля и создайте YAML спецификацию:
    ```bash
+   tvgen collect-full --scope crypto
    tvgen generate --market crypto --output openapi_crypto.yaml
    ```
 2. Откройте GPT Builder и выберите **Import from OpenAPI**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2",]
 
 [project.scripts]

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Scanner API
-  version: 0.8.27
+  version: 0.8.28
   description: Auto-generated from collected field data.
 servers:
   - url: https://scanner.tradingview.com


### PR DESCRIPTION
## Summary
- document `collect-full` workflow in `AGENTS.md`
- bump version to 0.8.28
- update CHANGELOG entry
- update README CLI, CI and GPT Builder instructions
- regenerate `specs/crypto.yaml`

## Testing
- `black .`
- `tvgen generate --market crypto --output specs/crypto.yaml`
- `tvgen validate --spec specs/crypto.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a89e5359c832cb762ed0c2d5f236b