### PR TITLE
Fix spec update workflow

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -17,6 +17,8 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
+    env:
+      SERVER_URL: ${{ secrets.SERVER_URL }}
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
@@ -38,8 +40,8 @@ jobs:
             types-requests types-PyYAML types-toml
           pip install -e .
       - name: Export server URL
-        if: ${{ secrets.SERVER_URL != '' }}
-        run: echo "SERVER_URL=${{ secrets.SERVER_URL }}" >> "$GITHUB_ENV"
+        if: env.SERVER_URL != ''
+        run: echo "SERVER_URL=${SERVER_URL}" >> "$GITHUB_ENV"
 
       - name: Collect full data
         run: |


### PR DESCRIPTION
## Summary
- handle missing SERVER_URL secret in spec-update workflow by mapping secret to env
- conditionally export the variable only when provided

## Testing
- `actionlint -oneline .github/workflows/spec-update.yml`
- `python codex_actions.py generate_openapi_spec`
- `python codex_actions.py validate_spec`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684aaf2466c4832c9b8404064e96d68d