### PR TITLE
Bump version to 0.8.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.30
+- Fixed artifact workflow to correctly upload generated specifications
 ## 0.8.29
 - Version bump
 ## 0.8.28

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2",]
 
 [project.scripts]

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Scanner API
-  version: 0.8.29
+  version: 0.8.30
   description: Auto-generated from collected field data.
 servers:
   - url: https://scanner.tradingview.com


### PR DESCRIPTION
## Summary
- bump package version to 0.8.30
- regenerate and validate crypto OpenAPI spec
- refine changelog entry

## Testing
- `pytest -q`
- `tvgen generate --market crypto --output specs/crypto.yaml`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684ad12f3a84832cb83987c1a03991c9