### PR TITLE
Implement data fetcher utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.32
+- Version bump
 ## 0.8.31
 - Version bump
 ## 0.8.30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2",]
 
 [project.scripts]

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,3 +1,3 @@
 """API wrappers for TradingView scanner."""
 
-__all__ = ["tradingview_api", "stock_data"]
+__all__ = ["tradingview_api", "stock_data", "data_fetcher"]

--- a/src/api/data_fetcher.py
+++ b/src/api/data_fetcher.py
@@ -1,0 +1,85 @@
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import requests
+from requests.adapters import HTTPAdapter, Retry
+
+
+def _get_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        backoff_factor=0.5,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET", "POST"],
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.headers.setdefault("User-Agent", "tv-generator")
+    return session
+
+
+def fetch_metainfo(
+    scope: str, api_base: str = "https://scanner.tradingview.com"
+) -> Dict:
+    """Return metainfo for a given scope using GET request."""
+    session = _get_session()
+    url = f"{api_base.rstrip('/')}/{scope}/metainfo"
+    resp = session.get(url, timeout=30)
+    resp.raise_for_status()
+    try:
+        return resp.json()
+    except ValueError as exc:  # pragma: no cover - should not happen in tests
+        raise ValueError("Invalid JSON received from TradingView") from exc
+
+
+def _chunks(seq: List[str], size: int) -> List[List[str]]:
+    return [seq[i : i + size] for i in range(0, len(seq), size)]  # noqa: E203
+
+
+def full_scan(
+    scope: str,
+    tickers: List[str],
+    columns: List[str],
+    api_base: str = "https://scanner.tradingview.com",
+) -> Dict:
+    """Perform a scan request splitting columns into batches."""
+    session = _get_session()
+    url = f"{api_base.rstrip('/')}/{scope}/scan"
+    batches = _chunks(columns, 20)
+    result: Dict | None = None
+    for cols in batches:
+        payload = {
+            "symbols": {"tickers": tickers, "query": {"types": []}},
+            "columns": cols,
+        }
+        resp = session.post(url, json=payload, timeout=30)
+        resp.raise_for_status()
+        try:
+            data = resp.json()
+        except ValueError as exc:  # pragma: no cover - should not happen in tests
+            raise ValueError("Invalid JSON received from TradingView") from exc
+        if result is None:
+            result = data
+        else:
+            res_rows = result.get("data", []) if isinstance(result, dict) else []
+            new_rows = data.get("data", []) if isinstance(data, dict) else []
+            for idx, row in enumerate(new_rows):
+                if idx < len(res_rows):
+                    dval = row.get("d") if isinstance(row, dict) else None
+                    res_d = (
+                        res_rows[idx].get("d")
+                        if isinstance(res_rows[idx], dict)
+                        else None
+                    )
+                    if isinstance(dval, list) and isinstance(res_d, list):
+                        res_d.extend(dval)
+    return result or {}
+
+
+def save_json(data: Dict, path: Path) -> None:
+    """Save dictionary as pretty JSON to given path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -1,0 +1,70 @@
+import json
+from pathlib import Path
+
+import pytest
+import requests
+
+from src.api.data_fetcher import fetch_metainfo, full_scan, save_json
+
+
+def test_fetch_metainfo(tv_api_mock):
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/stocks/metainfo",
+        json={"fields": []},
+    )
+    assert fetch_metainfo("stocks") == {"fields": []}
+
+
+def test_fetch_metainfo_error(tv_api_mock):
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/stocks/metainfo",
+        status_code=500,
+    )
+    with pytest.raises(requests.exceptions.HTTPError):
+        fetch_metainfo("stocks")
+
+
+def test_fetch_metainfo_invalid_json(tv_api_mock):
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/stocks/metainfo",
+        text="not-json",
+    )
+    with pytest.raises(ValueError):
+        fetch_metainfo("stocks")
+
+
+def test_full_scan_single_batch(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        json={"data": [{"d": [1, 2]}]},
+    )
+    result = full_scan("stocks", ["AAA"], ["c1", "c2"])
+    assert result["data"][0]["d"] == [1, 2]
+
+
+def test_full_scan_multi_batch(tv_api_mock):
+    first = {"data": [{"d": list(range(20))}]}
+    second = {"data": [{"d": [99]}]}
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        [{"json": first}, {"json": second}],
+    )
+    columns = [f"c{i}" for i in range(21)]
+    result = full_scan("stocks", ["AAA"], columns)
+    assert result["data"][0]["d"] == list(range(20)) + [99]
+
+
+def test_full_scan_error(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        status_code=404,
+    )
+    with pytest.raises(requests.exceptions.HTTPError):
+        full_scan("stocks", ["AAA"], ["c1"])
+
+
+def test_save_json(tmp_path: Path):
+    data = {"a": 1}
+    out = tmp_path / "out.json"
+    save_json(data, out)
+    assert json.loads(out.read_text()) == data


### PR DESCRIPTION
## Summary
- add data fetcher API helpers
- export new helpers in api package
- test metainfo and scan utilities
- bump version to 0.8.32

## Testing
- `python - <<'PY'
import codex_actions as ca
ca.generate_openapi_spec()
ca.validate_spec()
ca.run_tests()
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684adb61ceb4832cb58d457771ca30a3