### PR TITLE
Add data_manager field status builder

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,3 +1,3 @@
 """API wrappers for TradingView scanner."""
 
-__all__ = ["tradingview_api", "stock_data", "data_fetcher"]
+__all__ = ["tradingview_api", "stock_data", "data_fetcher", "data_manager"]

--- a/src/api/data_manager.py
+++ b/src/api/data_manager.py
@@ -1,0 +1,45 @@
+import pandas as pd
+from typing import Any
+from src.models import MetaInfoResponse
+
+
+def build_field_status(meta: MetaInfoResponse, scan: dict) -> pd.DataFrame:
+    """Return status for each field from meta based on scan results."""
+    rows = scan.get("data", []) if isinstance(scan, dict) else []
+    if not isinstance(rows, list):
+        rows = []
+
+    result = []
+    for idx, field in enumerate(meta.fields):
+        missing = False
+        values: list[Any] = []
+        for row in rows:
+            dval = row.get("d") if isinstance(row, dict) else None
+            if isinstance(dval, list) and idx < len(dval):
+                values.append(dval[idx])
+            else:
+                missing = True
+                break
+        if missing:
+            status = "error"
+            sample = ""
+        else:
+            non_zero = [v for v in values if v not in (None, "", [])]
+            if non_zero:
+                status = "ok"
+                sample = non_zero[0]
+            elif all(v is None for v in values):
+                status = "null"
+                sample = ""
+            else:
+                status = "empty"
+                sample = ""
+        result.append(
+            {
+                "field": field.n,
+                "tv_type": field.t,
+                "status": status,
+                "sample_value": sample,
+            }
+        )
+    return pd.DataFrame(result, columns=["field", "tv_type", "status", "sample_value"])

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from src.api.data_manager import build_field_status
+from src.models import MetaInfoResponse, TVField
+
+
+def _meta(fields):
+    return MetaInfoResponse(data=[TVField(name=f[0], type=f[1]) for f in fields])
+
+
+def test_build_field_status_basic():
+    meta = _meta(
+        [
+            ("f1", "integer"),
+            ("f2", "string"),
+            ("f3", "float"),
+        ]
+    )
+    scan = {"data": [{"d": [1, "", None]}, {"d": [2, "", None]}]}
+    df = build_field_status(meta, scan)
+    expected = pd.DataFrame(
+        {
+            "field": ["f1", "f2", "f3"],
+            "tv_type": ["integer", "string", "float"],
+            "status": ["ok", "empty", "null"],
+            "sample_value": [1, "", ""],
+        }
+    )
+    pd.testing.assert_frame_equal(df.reset_index(drop=True), expected)
+
+
+def test_build_field_status_missing():
+    meta = _meta([("f1", "integer"), ("f2", "string")])
+    scan = {"data": [{"d": [1]}, {"d": [2]}]}
+    df = build_field_status(meta, scan)
+    assert list(df["status"]) == ["ok", "error"]


### PR DESCRIPTION
## Summary
- implement `build_field_status` helper to analyze scan results
- expose `data_manager` module
- test field status builder

## Testing
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml` *(fails: Missing metainfo.json)*
- `tvgen validate --spec specs/openapi_crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684add251cd4832ca6f9f386001b5817