### PR TITLE
Add simplified collect-full and generate commands

### DIFF
--- a/codex_actions.py
+++ b/codex_actions.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 def generate_openapi_spec():
     """Run the CLI generator for the crypto market."""
-    spec_file = Path("specs/crypto.yaml")
     meta_file = Path("results/crypto/metainfo.json")
     if not meta_file.exists():
         meta_file.parent.mkdir(parents=True, exist_ok=True)
@@ -25,10 +24,12 @@ def generate_openapi_spec():
             [
                 "tvgen",
                 "generate",
-                "--market",
+                "--scope",
                 "crypto",
-                "--output",
-                str(spec_file),
+                "--indir",
+                "results",
+                "--outdir",
+                "specs",
             ],
             check=True,
             capture_output=True,

--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -66,7 +66,9 @@ def generate_yaml(
         for idx in range(0, len(fields), 64):
             part_num = idx // 64 + 1
             part_name = f"{cap}FieldsPart{part_num:02d}"
-            props = {name: schema for name, schema in fields[idx : idx + 64]}
+            props = {
+                name: schema for name, schema in fields[idx : idx + 64]  # noqa: E203
+            }
             openapi["components"]["schemas"][part_name] = {
                 "type": "object",
                 "properties": props,
@@ -178,7 +180,7 @@ def generate_yaml(
         }
     }
 
-    yaml_str = yaml.safe_dump(openapi, sort_keys=False, Dumper=_IndentedDumper)
+    yaml_str = yaml.dump(openapi, sort_keys=False, Dumper=_IndentedDumper)  # type: ignore  # noqa: E501
     if len(yaml_str.encode()) > max_size:
         raise RuntimeError("YAML size exceeds limit")
     print(yaml_str)

--- a/src/utils/type_mapping.py
+++ b/src/utils/type_mapping.py
@@ -7,6 +7,8 @@ TV_TYPE_TO_REF: dict[str, str] = {
     "fundamental_price": "#/components/schemas/Num",
     "percent": "#/components/schemas/Num",
     "integer": "#/components/schemas/Num",
+    "float": "#/components/schemas/Num",
+    "string": "#/components/schemas/Str",
     "bool": "#/components/schemas/Bool",
     "boolean": "#/components/schemas/Bool",
     "text": "#/components/schemas/Str",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,14 @@ def _create_metainfo(path: Path) -> None:
         }
     }
     path.write_text(json.dumps(data))
+    scan = {"data": [{"d": [1, "a"]}]}
+    (path.parent / "scan.json").write_text(json.dumps(scan))
+    tsv = (
+        "field\ttv_type\tstatus\tsample_value\n"
+        "close\tinteger\tok\t1\n"
+        "open\tstring\tok\ta\n"
+    )
+    (path.parent / "field_status.tsv").write_text(tsv)
 
 
 def test_cli_scan(tv_api_mock) -> None:
@@ -222,8 +230,8 @@ def test_generate_help() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["generate", "--help"])
     assert result.exit_code == 0
-    assert "--market" in result.output
-    assert "--results-dir" in result.output
+    assert "--scope" in result.output
+    assert "--indir" in result.output
 
 
 def test_cli_generate_and_validate(tmp_path: Path) -> None:
@@ -232,17 +240,17 @@ def test_cli_generate_and_validate(tmp_path: Path) -> None:
         market_dir = Path("results") / "crypto"
         _create_metainfo(market_dir / "metainfo.json")
 
-        out_file = Path("spec.yaml")
+        out_file = Path("crypto.yaml")
         result = runner.invoke(
             cli,
             [
                 "generate",
-                "--market",
+                "--scope",
                 "crypto",
-                "--output",
-                str(out_file),
-                "--results-dir",
+                "--indir",
                 str(Path("results")),
+                "--outdir",
+                str(Path(".")),
             ],
         )
         assert result.exit_code == 0
@@ -266,22 +274,21 @@ def test_cli_generate_missing_results(tmp_path: Path) -> None:
     runner = CliRunner()
     with runner.isolated_filesystem():
         (Path("results") / "crypto").mkdir(parents=True)
-        out_file = Path("spec.yaml")
         result = runner.invoke(
             cli,
             [
                 "generate",
-                "--market",
+                "--scope",
                 "crypto",
-                "--output",
-                str(out_file),
-                "--results-dir",
+                "--indir",
                 str(Path("results")),
+                "--outdir",
+                str(Path(".")),
             ],
         )
         assert result.exit_code != 0
         assert result.exception is not None
-        assert "Missing metainfo.json" in result.output
+        assert "No such file" in result.output
 
 
 def test_cli_scan_error(tv_api_mock) -> None:
@@ -352,61 +359,57 @@ def test_cli_validate_invalid_yaml(tmp_path: Path) -> None:
     assert result.exception is not None
 
 
-def _mock_collect_api(tv_api_mock) -> None:
-    tv_api_mock.post(
-        "https://scanner.tradingview.com/crypto/metainfo",
-        json={
-            "data": {
-                "fields": [
-                    {"name": "close", "type": "integer"},
-                    {"name": "open", "type": "string"},
-                ],
-                "index": {"names": ["AAA", "BBB"]},
-            }
-        },
-    )
-    tv_api_mock.get(
-        "https://scanner.tradingview.com/crypto/scan",
-        json={"data": [{"d": [1, "a"]}, {"d": [2, "b"]}]},
-    )
+def _mock_collect_api(monkeypatch) -> None:
+    meta = {
+        "fields": [
+            {"name": "close", "type": "integer"},
+            {"name": "open", "type": "string"},
+        ],
+        "index": {"names": ["AAA", "BBB"]},
+    }
+
+    def fake_meta(scope: str) -> dict:
+        return meta
+
+    def fake_scan(scope: str, tickers: list[str], columns: list[str]) -> dict:
+        return {"data": [{"d": [1, "a"]}, {"d": [2, "b"]}]}
+
+    monkeypatch.setattr("src.cli.fetch_metainfo", fake_meta)
+    monkeypatch.setattr("src.cli.full_scan", fake_scan)
 
 
-def test_collect_full_success(tv_api_mock):
+def test_collect_full_success(monkeypatch):
     runner = CliRunner()
-    _mock_collect_api(tv_api_mock)
+    _mock_collect_api(monkeypatch)
     with runner.isolated_filesystem():
-        result = runner.invoke(
-            cli,
-            ["collect-full", "--scope", "crypto", "--tickers", "AAA,BBB"],
-        )
+        result = runner.invoke(cli, ["collect-full", "--scope", "crypto"])
         assert result.exit_code == 0
         base = Path("results/crypto")
         assert (base / "metainfo.json").exists()
         assert (base / "scan.json").exists()
         status_lines = (base / "field_status.tsv").read_text().splitlines()
-        assert status_lines[0] == "field\ttype\tstatus\tsample_value"
+        assert status_lines[0] == "field\ttv_type\tstatus\tsample_value"
         assert "close\tinteger\tok\t1" in status_lines[1]
         assert "open\tstring\tok\ta" in status_lines[2]
 
 
-def test_collect_full_alias(tv_api_mock):
+def test_collect_full_alias(monkeypatch):
     runner = CliRunner()
-    _mock_collect_api(tv_api_mock)
+    _mock_collect_api(monkeypatch)
     with runner.isolated_filesystem():
-        result = runner.invoke(
-            cli, ["collect", "--scope", "crypto", "--tickers", "AAA,BBB"]
-        )
+        result = runner.invoke(cli, ["collect", "--scope", "crypto"])
         assert result.exit_code == 0
 
 
-def test_collect_full_error(tv_api_mock):
+def test_collect_full_error(monkeypatch):
     runner = CliRunner()
-    tv_api_mock.post("https://scanner.tradingview.com/crypto/metainfo", status_code=500)
+    monkeypatch.setattr(
+        "src.cli.fetch_metainfo",
+        lambda scope: (_ for _ in ()).throw(FileNotFoundError("boom")),
+    )
+    monkeypatch.setattr("src.cli.full_scan", lambda scope, tickers, columns: {})
     with runner.isolated_filesystem():
-        result = runner.invoke(
-            cli,
-            ["collect-full", "--scope", "crypto", "--tickers", "AAA,BBB"],
-        )
+        result = runner.invoke(cli, ["collect-full", "--scope", "crypto"])
         assert result.exit_code != 0
         log = Path("results/crypto/error.log").read_text()
         assert log


### PR DESCRIPTION
## Summary
- add new simplified `collect-full` command that uses data_fetcher helpers
- add new `generate` command that loads JSON/TSV and calls `generate_yaml`
- adjust utilities for new field types
- update tests for new CLI behaviour

## Testing
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `python codex_actions.py generate_openapi_spec`
- `python codex_actions.py validate_spec`


------
https://chatgpt.com/codex/tasks/task_e_684ae123ed90832c909f0d5891187337