### PR TITLE
Add daily spec workflow

### DIFF
--- a/.github/workflows/daily-specs.yml
+++ b/.github/workflows/daily-specs.yml
@@ -1,0 +1,49 @@
+---
+# yamllint disable rule:truthy rule:line-length
+name: daily-specs
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry openapi-spec-validator
+      - name: Install dependencies
+        run: |
+          poetry install --no-interaction --no-root
+      - name: Collect full data
+        run: poetry run tvgen collect-full --scope coin
+      - name: Generate spec
+        run: poetry run tvgen generate --scope coin
+      - name: Validate generated spec
+        run: openapi-spec-validator specs/coin.yaml
+      - name: Check size limit
+        run: python -c "import os,sys; s=os.path.getsize('specs/coin.yaml'); assert s<1048576"
+      - name: Commit results and spec
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: |
+            results/**
+            specs/coin.yaml
+          message: 'chore: update coin spec'
+          default_author: github_actions
+      - name: Finish
+        run: exit 0


### PR DESCRIPTION
## Summary
- add `daily-specs` workflow to update `coin` specs nightly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684aeeb5c92c832ca01592260b22b37a