### PR TITLE
Update type mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.34
+- Version bump
 ## 0.8.33
 - Version bump
 ## 0.8.32

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2",]
 
 [project.scripts]

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 0.8.33
+  version: 0.8.34
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -127,6 +127,8 @@ components:
       properties:
         close:
           $ref: '#/components/schemas/Num'
+        open:
+          $ref: '#/components/schemas/Str'
     CryptoScanRequest:
       type: object
       properties:

--- a/src/utils/type_mapping.py
+++ b/src/utils/type_mapping.py
@@ -7,8 +7,6 @@ TV_TYPE_TO_REF: dict[str, str] = {
     "fundamental_price": "#/components/schemas/Num",
     "percent": "#/components/schemas/Num",
     "integer": "#/components/schemas/Num",
-    "float": "#/components/schemas/Num",
-    "string": "#/components/schemas/Str",
     "bool": "#/components/schemas/Bool",
     "boolean": "#/components/schemas/Bool",
     "text": "#/components/schemas/Str",

--- a/tests/assets/coin_metainfo.json
+++ b/tests/assets/coin_metainfo.json
@@ -1,13 +1,13 @@
 {
   "data": {
     "fields": [
-      {"name": "close", "type": "float"},
-      {"name": "open", "type": "float"},
+      {"name": "close", "type": "number"},
+      {"name": "open", "type": "number"},
       {"name": "volume", "type": "integer"},
-      {"name": "exchange", "type": "string"},
+      {"name": "exchange", "type": "text"},
       {"name": "is_hot", "type": "boolean"},
       {"name": "timestamp", "type": "time"},
-      {"name": "deprecated_field", "type": "string", "flags": ["deprecated"]},
+      {"name": "deprecated_field", "type": "text", "flags": ["deprecated"]},
       {"name": "private_field", "type": "integer", "flags": ["private"]}
     ],
     "index": {"names": ["BINANCE:BTCUSDT", "COINBASE:ETHUSD"]}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ def _create_metainfo(path: Path) -> None:
         "data": {
             "fields": [
                 {"name": "close", "type": "integer"},
-                {"name": "open", "type": "string"},
+                {"name": "open", "type": "text"},
             ]
         }
     }
@@ -23,7 +23,7 @@ def _create_metainfo(path: Path) -> None:
     tsv = (
         "field\ttv_type\tstatus\tsample_value\n"
         "close\tinteger\tok\t1\n"
-        "open\tstring\tok\ta\n"
+        "open\ttext\tok\ta\n"
     )
     (path.parent / "field_status.tsv").write_text(tsv)
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,8 +12,8 @@ def test_e2e_collect_and_generate(tmp_path, monkeypatch):
         "data": {
             "fields": [
                 {"name": "field1", "type": "integer"},
-                {"name": "field2", "type": "float"},
-                {"name": "field3", "type": "string"},
+                {"name": "field2", "type": "number"},
+                {"name": "field3", "type": "text"},
                 {"name": "field4", "type": "boolean"},
                 {"name": "field5", "type": "time"},
             ],


### PR DESCRIPTION
## Summary
- update TV type mapping to support a reduced set of 13 types
- align tests with revised TV types
- regenerate crypto OpenAPI spec
- bump version to 0.8.34

## Testing
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --scope crypto --indir results --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684af4b76d28832c8e1c7299d47fe167