### PR TITLE
Add Pydantic models and dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.35
+- Version bump
 ## 0.8.34
 - Version bump
 ## 0.8.33

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.34"
-dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2",]
+version = "0.8.35"
+dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]
 tvgen = "src.cli:cli"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ requests_mock
 click>=8.2
 toml>=0.10
 requests_cache>=1.2
+pydantic>=2.7
 types-requests
 types-PyYAML
 types-toml

--- a/src/models.py
+++ b/src/models.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 
-class TVField(BaseModel):
+class TVBaseModel(BaseModel):
+    """Base model with compatibility helpers."""
+
+    @classmethod
+    def parse_obj(cls, obj: Any) -> "TVBaseModel":
+        """Create an instance from a parsed object (pydantic v1 style)."""
+        return cls.model_validate(obj)
+
+
+class TVField(TVBaseModel):
     """TradingView field description."""
 
     n: str = Field(alias="name")
@@ -11,23 +22,37 @@ class TVField(BaseModel):
     flags: list[str] | None = None
 
 
-class MetaInfoResponse(BaseModel):
+class MetaInfoResponse(TVBaseModel):
     """Response containing field metadata."""
 
     data: list[TVField]
+
+    @classmethod
+    def parse_obj(cls, obj: Any) -> "MetaInfoResponse":
+        """Parse TradingView metainfo JSON into a model."""
+        if isinstance(obj, dict):
+            fields_json = None
+            if isinstance(obj.get("data"), dict):
+                fields_json = obj.get("data", {}).get("fields")
+            if fields_json is None:
+                fields_json = obj.get("fields")
+            if isinstance(fields_json, list):
+                fields = [TVField.parse_obj(f) for f in fields_json]
+                return cls(data=fields)
+        return super().parse_obj(obj)
 
     @property
     def fields(self) -> list[TVField]:
         return self.data
 
 
-class ScanItem(BaseModel):
+class ScanItem(TVBaseModel):
     """Single scan item."""
 
     d: list[object]
 
 
-class ScanResponse(BaseModel):
+class ScanResponse(TVBaseModel):
     """Response for scan results."""
 
     data: list[ScanItem]


### PR DESCRIPTION
## Summary
- add `pydantic` dependency
- implement `TVBaseModel` and parsing helpers
- update models so `MetaInfoResponse.parse_obj()` accepts TradingView metainfo
- bump package version

## Testing
- `pytest -q`
- `python codex_actions.py generate_openapi_spec`
- `python codex_actions.py validate_spec`


------
https://chatgpt.com/codex/tasks/task_e_684af6376ffc832c9c5b43b75ae2d0a5