### PR TITLE
Add CLI generate spec size test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.8.39
+- Version bump
 ## 0.8.38
 - Version bump
 ## 0.8.37

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 0.8.37
+  version: 0.8.39
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/tests/test_size_limit.py
+++ b/tests/test_size_limit.py
@@ -40,3 +40,25 @@ def test_size_limit() -> None:
         spec_file = Path("coin.yaml")
         assert spec_file.exists()
         assert spec_file.stat().st_size < 1_048_576
+
+
+def test_generate_to_specs_dir() -> None:
+    """CLI 'generate' creates specs/coin.yaml under 1 MB using fixture data."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        market_dir = Path("results") / "coin"
+        _prepare(market_dir)
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "--scope",
+                "coin",
+                "--indir",
+                str(Path("results")),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        spec_file = Path("specs/coin.yaml")
+        assert spec_file.exists()
+        assert spec_file.stat().st_size < 1_048_576


### PR DESCRIPTION
## Summary
- bump version to 0.8.39
- regenerate crypto spec
- add test for generating specs/coin.yaml under size limit

## Testing
- `mypy src/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684afe9a06c0832c83e9a89dff07eb1f