### PR TITLE
Bump to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [1.0.0] – 2025-06-12
+### Added
+* Daily multi-market pipeline (collect-full / generate)
+* OpenAPI 3.1 generation with GPT-Builder extensions
+### Fixed
+* Size-limit guard < 1 MB
 ## 0.8.40
 - Version bump
 ## 0.8.39

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "0.8.40"
+version = "1.0.0"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- bump package version to 1.0.0
- start changelog for 1.0.0 release

## Testing
- `python - <<'PY'
import codex_actions as c
c.generate_openapi_spec()
PY
` *(fails: tvgen command not found)*
- `python - <<'PY'
import codex_actions as c
c.validate_spec()
PY
` *(fails: tvgen command not found)*
- `python - <<'PY'
import codex_actions as c
c.run_tests()
PY
` *(fails: ModuleNotFoundError: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_e_684b0878362c832cb2c4d40349933f3a