### PR TITLE
Add enum/description generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.3
+- Version bump
 ## 1.0.2
 - Version bump
 ## 1.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,14 +2,15 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.1
+  version: 1.0.2
 servers:
   - url: https://scanner.tradingview.com
 paths:
   /crypto/scan:
     post:
-      summary: Scan crypto
-      description: Scan crypto
+      summary: Scan crypto market data
+      description: 'Send a CryptoScanRequest payload and receive a CryptoScanResponse.
+        The response contains fields defined in #/components/schemas/CryptoFields.'
       operationId: CryptoScan
       x-openai-isConsequential: false
       requestBody:
@@ -30,8 +31,9 @@ paths:
           description: Server Error
   /crypto/search:
     post:
-      summary: Search crypto
-      description: Search crypto
+      summary: Search crypto market data
+      description: 'Send a CryptoSearchRequest payload and receive a CryptoSearchResponse.
+        The response contains fields defined in #/components/schemas/CryptoFields.'
       operationId: CryptoSearch
       x-openai-isConsequential: false
       requestBody:
@@ -52,8 +54,9 @@ paths:
           description: Server Error
   /crypto/history:
     post:
-      summary: History crypto
-      description: History crypto
+      summary: History crypto market data
+      description: 'Send a CryptoHistoryRequest payload and receive a CryptoHistoryResponse.
+        The response contains fields defined in #/components/schemas/CryptoFields.'
       operationId: CryptoHistory
       x-openai-isConsequential: false
       requestBody:
@@ -74,8 +77,9 @@ paths:
           description: Server Error
   /crypto/summary:
     post:
-      summary: Summary crypto
-      description: Summary crypto
+      summary: Summary crypto market data
+      description: 'Send a CryptoSummaryRequest payload and receive a CryptoSummaryResponse.
+        The response contains fields defined in #/components/schemas/CryptoFields.'
       operationId: CryptoSummary
       x-openai-isConsequential: false
       requestBody:
@@ -97,7 +101,7 @@ paths:
   /crypto/metainfo:
     post:
       summary: Get crypto metainfo
-      description: Get crypto metainfo
+      description: Returns the list of available fields for crypto.
       operationId: CryptoMetainfo
       x-openai-isConsequential: false
       responses:
@@ -130,8 +134,10 @@ components:
       properties:
         close:
           $ref: '#/components/schemas/Num'
+          description: Close
         open:
           $ref: '#/components/schemas/Str'
+          description: Open
     CryptoScanRequest:
       type: object
       properties:

--- a/src/cli.py
+++ b/src/cli.py
@@ -313,7 +313,7 @@ def generate(scope: str, indir: Path, outdir: Path, max_size: int) -> None:
 
     try:
         meta_data = json.loads(meta_file.read_text())
-        json.loads(scan_file.read_text())
+        scan_data = json.loads(scan_file.read_text())
         tsv = pd.read_csv(status_file, sep="\t")
     except FileNotFoundError as exc:
         raise click.ClickException(str(exc))
@@ -331,7 +331,7 @@ def generate(scope: str, indir: Path, outdir: Path, max_size: int) -> None:
                 )
     meta = MetaInfoResponse(data=tv_fields)
 
-    yaml_str = generate_yaml(scope, meta, tsv, max_size=max_size)
+    yaml_str = generate_yaml(scope, meta, tsv, scan_data, max_size=max_size)
 
     outdir.mkdir(parents=True, exist_ok=True)
     out_file = outdir / f"{scope}.yaml"

--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, Dict, TYPE_CHECKING, Iterable
 
 import toml
 import yaml
@@ -20,10 +20,51 @@ class _IndentedDumper(yaml.SafeDumper):
         super().increase_indent(flow, False)
 
 
+def _timeframe_desc(value: str | int) -> str:
+    """Return a human friendly timeframe description."""
+    try:
+        minutes = int(value)
+    except Exception:
+        return str(value)
+    if minutes % 1440 == 0:
+        days = minutes // 1440
+        return f"{days}-day" if days > 1 else "1-day"
+    if minutes % 60 == 0:
+        hours = minutes // 60
+        return f"{hours}-hour" if hours > 1 else "1-hour"
+    return f"{minutes}-minute"
+
+
+_INDICATOR_NAMES = {
+    "RSI": "Relative Strength Index",
+    "EMA": "Exponential Moving Average",
+    "ADX+DI": "Average Directional Index + Directional Indicator",
+}
+
+
+def _indicator_name(raw: str) -> str:
+    for key, val in _INDICATOR_NAMES.items():
+        if raw.startswith(key):
+            if key == "EMA" and raw != "EMA":
+                period = raw[len("EMA") :]
+                if period.isdigit():
+                    return f"{val} ({period})"
+            return val
+    return raw.replace("_", " ").title()
+
+
+def _describe_field(name: str) -> str:
+    if "|" in name:
+        base, tf = name.split("|", 1)
+        return f"{_indicator_name(base)} on {_timeframe_desc(tf)} timeframe"
+    return _indicator_name(name)
+
+
 def generate_yaml(
     scope: str,
     meta: MetaInfoResponse,
     _tsv: "pd.DataFrame",
+    scan: dict | None = None,
     server_url: str = "https://scanner.tradingview.com",
     max_size: int = 1_048_576,
 ) -> str:
@@ -34,11 +75,37 @@ def generate_yaml(
     version = toml.load(root / "pyproject.toml")["project"]["version"]
 
     fields: list[tuple[str, Dict[str, Any]]] = []
-    for field in meta.fields:
+    scan_rows = scan.get("data", []) if isinstance(scan, dict) else []
+    for idx, field in enumerate(meta.fields):
         flags = set(field.flags or [])
         if {"deprecated", "private"} & flags:
             continue
-        fields.append((field.n, {"$ref": tv2ref(field.t)}))
+        schema: Dict[str, Any] = {"$ref": tv2ref(field.t)}
+        schema["description"] = _describe_field(field.n)
+
+        values: list[Any] = []
+        for row in scan_rows:
+            dval = row.get("d") if isinstance(row, dict) else None
+            if isinstance(dval, list) and idx < len(dval):
+                val = dval[idx]
+                if val not in (None, ""):
+                    values.append(val)
+        unique_vals = sorted({v for v in values})
+        if 1 < len(unique_vals) <= 10:
+            schema["enum"] = unique_vals
+
+        base_name = field.n.split("|", 1)[0]
+        examples = {
+            "RSI": 55,
+            "EMA20": 50,
+            "ADX+DI": 25,
+        }
+        for key, example in examples.items():
+            if base_name.startswith(key):
+                schema["example"] = example
+                break
+
+        fields.append((field.n, schema))
 
     fields.sort(key=lambda x: x[0])
 
@@ -129,8 +196,12 @@ def generate_yaml(
     def _add(path: str, req: str, resp: str) -> None:
         openapi["paths"][f"/{scope}/{path}"] = {
             "post": {
-                "summary": f"{path.capitalize()} {scope}",
-                "description": f"{path.capitalize()} {scope}",
+                "summary": f"{path.capitalize()} {scope} market data",
+                "description": (
+                    f"Send a {cap}{req} payload and receive a {cap}{resp}. "
+                    f"The response contains fields defined in "
+                    + f"#/components/schemas/{cap}Fields."
+                ),
                 "operationId": f"{cap}{path.capitalize()}",
                 "x-openai-isConsequential": False,
                 "requestBody": {
@@ -163,7 +234,7 @@ def generate_yaml(
     openapi["paths"][f"/{scope}/metainfo"] = {
         "post": {
             "summary": f"Get {scope} metainfo",
-            "description": f"Get {scope} metainfo",
+            "description": f"Returns the list of available fields for {scope}.",
             "operationId": f"{cap}Metainfo",
             "x-openai-isConsequential": False,
             "responses": {

--- a/tests/test_field_coverage.py
+++ b/tests/test_field_coverage.py
@@ -20,7 +20,7 @@ def _load_meta() -> MetaInfoResponse:
 def test_field_coverage() -> None:
     meta = _load_meta()
     tsv = pd.DataFrame(columns=["field", "tv_type", "status", "sample_value"])
-    yaml_str = generate_yaml("coin", meta, tsv)
+    yaml_str = generate_yaml("coin", meta, tsv, None)
     spec = yaml.safe_load(yaml_str)
     props = spec["components"]["schemas"]["CoinFields"]["properties"]
     yaml_fields = set(props.keys())

--- a/tests/test_yaml_generator.py
+++ b/tests/test_yaml_generator.py
@@ -18,7 +18,7 @@ def test_generate_yaml() -> None:
     meta = _sample_meta()
     tsv = pd.DataFrame(columns=["field", "tv_type", "status", "sample_value"])
     with mock.patch("toml.load", return_value={"project": {"version": "1.2.3"}}):
-        yaml_str = generate_yaml("crypto", meta, tsv)
+        yaml_str = generate_yaml("crypto", meta, tsv, None)
     data = yaml.safe_load(yaml_str)
     assert data["info"]["version"] == "1.2.3"
     assert "/crypto/scan" in data["paths"]
@@ -41,4 +41,4 @@ def test_generate_yaml_size_limit() -> None:
     tsv = pd.DataFrame()
     with mock.patch("toml.load", return_value={"project": {"version": "1.0"}}):
         with pytest.raises(RuntimeError):
-            generate_yaml("crypto", meta, tsv, max_size=10)
+            generate_yaml("crypto", meta, tsv, None, max_size=10)


### PR DESCRIPTION
## Summary
- enrich yaml_generator with automatic descriptions, enums, and examples
- feed scan results to generator via CLI
- bump version to 1.0.3

## Testing
- `pytest -q`
- `tvgen generate --market crypto --output specs/openapi_crypto.yaml`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684b2a84bb74832c8c4a63784dd0295a