### PR TITLE
Add strict validation models and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.5
+- Version bump
 ## 1.0.4
 - Version bump
 ## 1.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]

--- a/src/api/stock_data.py
+++ b/src/api/stock_data.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 from .tradingview_api import TradingViewAPI
+from pydantic import ValidationError
 from src.utils.payload import build_scan_payload
 
 logger = logging.getLogger(__name__)
@@ -10,7 +11,11 @@ logger = logging.getLogger(__name__)
 def _fetch_field(symbol: str, scope: str, column: str, error_msg: str) -> Any:
     api = TradingViewAPI()
     payload = build_scan_payload([symbol], [column])
-    data = api.scan(scope, payload)
+    try:
+        data = api.scan(scope, payload)
+    except ValidationError as exc:
+        logger.error("Invalid scan response for %s in %s: %s", symbol, scope, exc)
+        raise ValueError(f"{error_msg} for {symbol} in market {scope}") from exc
     try:
         return data["data"][0]["d"][0]
     except (KeyError, IndexError) as exc:

--- a/src/api/tradingview_api.py
+++ b/src/api/tradingview_api.py
@@ -7,6 +7,7 @@ from requests.adapters import HTTPAdapter, Retry
 import requests_cache
 
 from src.constants import SCOPES
+from src.models import MetaInfoResponse, ScanResponse
 
 logger = logging.getLogger(__name__)
 
@@ -90,12 +91,16 @@ class TradingViewAPI:
         return f"{self.base_url}/{scope}/{endpoint}"
 
     def scan(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """Send GET /{scope}/scan and return JSON."""
-        return self._request(scope, "scan", "GET", payload)
+        """Send GET /{scope}/scan and return JSON validated by ``ScanResponse``."""
+        data = self._request(scope, "scan", "GET", payload)
+        ScanResponse.parse_obj(data)
+        return data
 
     def metainfo(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """Fetch metainfo for scope."""
-        return self._request(scope, "metainfo", "POST", payload)
+        """Fetch metainfo for scope validated by ``MetaInfoResponse``."""
+        data = self._request(scope, "metainfo", "POST", payload)
+        MetaInfoResponse.parse_obj(data)
+        return data
 
     def search(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         """POST /{scope}/search."""

--- a/src/cli.py
+++ b/src/cli.py
@@ -20,7 +20,7 @@ from src.utils.payload import build_scan_payload
 from src.generator.yaml_generator import generate_yaml
 from src.api.data_fetcher import fetch_metainfo, full_scan, save_json, choose_tickers
 from src.api.data_manager import build_field_status
-from src.models import TVField, MetaInfoResponse
+from src.models import TVField, MetaInfoResponse, ScanResponse
 from src.constants import SCOPES
 import pandas as pd
 
@@ -341,6 +341,10 @@ def generate(market: str, indir: Path, outdir: Path, max_size: int) -> None:
         tsv = pd.read_csv(status_file, sep="\t")
     except FileNotFoundError as exc:
         raise click.ClickException(str(exc))
+
+    # Validate TradingView JSON
+    MetaInfoResponse.parse_obj(meta_data)
+    ScanResponse.parse_obj(scan_data)
 
     fields_json = (
         meta_data.get("fields") or meta_data.get("data", {}).get("fields") or []

--- a/src/models.py
+++ b/src/models.py
@@ -1,8 +1,28 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, cast, ClassVar, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, constr, confloat, AliasChoices
+
+# Accepted TradingView field types
+FieldType = Literal[
+    "number",
+    "price",
+    "fundamental_price",
+    "percent",
+    "integer",
+    "float",
+    "string",
+    "bool",
+    "boolean",
+    "text",
+    "map",
+    "set",
+    "interface",
+    "time",
+    "time-yyyymmdd",
+    "array",
+]
 
 
 class TVBaseModel(BaseModel):
@@ -17,8 +37,10 @@ class TVBaseModel(BaseModel):
 class TVField(TVBaseModel):
     """TradingView field description."""
 
-    n: str = Field(alias="name")
-    t: str = Field(alias="type")
+    n: constr(strip_whitespace=True, min_length=1) = Field(alias="name")
+    t: FieldType = Field(alias="type")
+    interval: confloat(gt=0) | None = None
+    description: constr(strip_whitespace=True, min_length=1) | None = None
     flags: list[str] | None = None
 
 
@@ -49,6 +71,7 @@ class MetaInfoResponse(TVBaseModel):
 class ScanItem(TVBaseModel):
     """Single scan item."""
 
+    s: constr(strip_whitespace=True, min_length=1)
     d: list[object]
 
 
@@ -56,6 +79,9 @@ class ScanResponse(TVBaseModel):
     """Response for scan results."""
 
     data: list[ScanItem]
+    count: int | None = Field(
+        default=None, validation_alias=AliasChoices("count", "totalCount")
+    )
 
 
 __all__ = ["TVField", "MetaInfoResponse", "ScanItem", "ScanResponse"]

--- a/tests/assets/coin_scan.json
+++ b/tests/assets/coin_scan.json
@@ -1,9 +1,12 @@
 {
+  "count": 2,
   "data": [
     {
+      "s": "BINANCE:BTCUSD",
       "d": [50000.0, 50500.0, 1500, "BINANCE", true, "2024-01-01T00:00:00Z", "old", 1]
     },
     {
+      "s": "COINBASE:ETHUSD",
       "d": [48000.0, 49000.0, 2000, "COINBASE", false, "2024-01-02T00:00:00Z", "old", 2]
     }
   ]

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -36,15 +36,15 @@ def test_fetch_metainfo_invalid_json(tv_api_mock):
 def test_full_scan_single_batch(tv_api_mock):
     tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
-        json={"data": [{"d": [1, 2]}]},
+        json={"count": 1, "data": [{"s": "AAA", "d": [1, 2]}]},
     )
     result = full_scan("stocks", ["AAA"], ["c1", "c2"])
     assert result["data"][0]["d"] == [1, 2]
 
 
 def test_full_scan_multi_batch(tv_api_mock):
-    first = {"data": [{"d": list(range(20))}]}
-    second = {"data": [{"d": [99]}]}
+    first = {"count": 1, "data": [{"s": "AAA", "d": list(range(20))}]}
+    second = {"count": 1, "data": [{"s": "AAA", "d": [99]}]}
     tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         [{"json": first}, {"json": second}],

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -21,10 +21,11 @@ def test_e2e_collect_and_generate(tmp_path, monkeypatch):
         }
     }
     scan = {
+        "count": 2,
         "data": [
-            {"d": [1, 1.1, "a", True, "2024-01-01T00:00:00Z"]},
-            {"d": [2, 2.2, "b", False, "2024-01-02T00:00:00Z"]},
-        ]
+            {"s": "AAA", "d": [1, 1.1, "a", True, "2024-01-01T00:00:00Z"]},
+            {"s": "BBB", "d": [2, 2.2, "b", False, "2024-01-02T00:00:00Z"]},
+        ],
     }
 
     monkeypatch.setattr("src.cli.fetch_metainfo", lambda scope: meta)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+import pytest
+from pydantic import ValidationError
+
+from src.models import MetaInfoResponse, ScanResponse
+
+ASSETS = Path(__file__).parent / "assets"
+
+
+def test_metainfo_asset_validation() -> None:
+    data = json.loads((ASSETS / "coin_metainfo.json").read_text())
+    model = MetaInfoResponse.parse_obj(data)
+    assert model.fields[0].n == "close"
+
+
+def test_scan_asset_validation() -> None:
+    data = json.loads((ASSETS / "coin_scan.json").read_text())
+    model = ScanResponse.parse_obj(data)
+    assert model.count == 2
+    assert model.data[0].s.startswith("BINANCE")
+
+
+def test_scan_invalid() -> None:
+    with pytest.raises(ValidationError):
+        ScanResponse.parse_obj({"data": [{"d": []}]})

--- a/tests/test_stock_data.py
+++ b/tests/test_stock_data.py
@@ -6,7 +6,7 @@ from src.api.stock_data import fetch_recommendation, fetch_stock_value
 def test_fetch_recommendation(tv_api_mock):
     tv_api_mock.get(
         "https://scanner.tradingview.com/stocks/scan",
-        json={"data": [{"d": ["strong_buy"]}]},
+        json={"count": 1, "data": [{"s": "AAPL", "d": ["strong_buy"]}]},
     )
     assert fetch_recommendation("AAPL") == "strong_buy"
 
@@ -14,7 +14,7 @@ def test_fetch_recommendation(tv_api_mock):
 def test_fetch_stock_value(tv_api_mock):
     tv_api_mock.get(
         "https://scanner.tradingview.com/stocks/scan",
-        json={"data": [{"d": [150.0]}]},
+        json={"count": 1, "data": [{"s": "AAPL", "d": [150.0]}]},
     )
     assert fetch_stock_value("AAPL") == 150.0
 


### PR DESCRIPTION
## Summary
- enforce strict types in models with `Literal`/`constr`/`confloat`
- add `count` and symbol handling for scan responses
- validate TradingView responses using pydantic models
- add regression tests for model validation
- bump version to 1.0.5

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b2edec724832ca5cf086907514170