### PR TITLE
Ensure spec size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,12 @@ jobs:
           for spec in specs/openapi_*.yaml; do
             openapi-spec-validator "$spec"
           done
+      - name: Check spec sizes
+        run: |
+          for spec in specs/*.yaml; do
+            size=$(wc -c < "$spec")
+            if [ "$size" -ge 1048576 ]; then
+              echo "${spec} is ${size} bytes, exceeds 1 MB" >&2
+              exit 1
+            fi
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.6
+- Version bump
 ## 1.0.5
 - Version bump
 ## 1.0.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.4
+  version: 1.0.6
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/tests/test_size_limit.py
+++ b/tests/test_size_limit.py
@@ -83,3 +83,12 @@ def test_collect_full_auto_tickers(monkeypatch) -> None:
         result = runner.invoke(cli, ["collect-full", "--market", "coin"])
         assert result.exit_code == 0, result.output
         assert len(sent["tickers"]) <= 10
+
+
+def test_repo_specs_size() -> None:
+    """All repository YAML specs should be under 1 MB."""
+    specs_dir = Path(__file__).resolve().parents[1] / "specs"
+    for spec in specs_dir.glob("*.yaml"):
+        assert (
+            spec.stat().st_size < 1_048_576
+        ), f"{spec.name} is {spec.stat().st_size} bytes, exceeds 1 MB"


### PR DESCRIPTION
## Summary
- enforce spec files under 1 MB in CI
- test that every YAML spec stays under the limit
- bump version

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b335d0db4832ca6f36b9a5b55b86e