### PR TITLE
Implement PR-based spec updates

### DIFF
--- a/.github/workflows/daily-specs.yml
+++ b/.github/workflows/daily-specs.yml
@@ -37,13 +37,21 @@ jobs:
         run: openapi-spec-validator specs/coin.yaml
       - name: Check size limit
         run: python -c "import os,sys; s=os.path.getsize('specs/coin.yaml'); assert s<1048576"
-      - name: Commit results and spec
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: |
-            results/**
-            specs/coin.yaml
-          message: 'chore: update coin spec'
-          default_author: github_actions
+      - name: Commit and create PR if spec changed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          if git diff --quiet HEAD -- specs/coin.yaml; then
+            echo "No changes detected"
+            exit 0
+          fi
+          branch="coin-spec-${{ github.run_number }}"
+          git checkout -b "$branch"
+          git add results/** specs/coin.yaml
+          git commit -m 'chore: update coin spec'
+          git push origin "$branch"
+          gh pr create --title 'Update coin spec' --body 'Спецификация обновлена автоматически на основе новых данных с TradingView /metainfo'
       - name: Finish
         run: exit 0

--- a/.github/workflows/generate-specs.yml
+++ b/.github/workflows/generate-specs.yml
@@ -1,0 +1,86 @@
+---
+name: generate-specs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Run codex actions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python - <<'PY'
+          import subprocess
+          from codex_actions import (
+              generate_openapi_spec,
+              validate_spec,
+              run_tests,
+              format_code,
+              bump_version,
+              create_pull_request,
+          )
+
+          generate_openapi_spec()
+          validate_spec()
+          run_tests()
+          format_code()
+          bump_version()
+
+          res = subprocess.run([
+              "git",
+              "diff",
+              "--quiet",
+              "specs/crypto.yaml",
+          ])
+          if res.returncode == 0:
+              print("No spec changes detected")
+          else:
+              subprocess.run([
+                  "git",
+                  "config",
+                  "user.email",
+                  "github-actions[bot]@users.noreply.github.com",
+              ], check=True)
+              subprocess.run([
+                  "git",
+                  "config",
+                  "user.name",
+                  "github-actions[bot]",
+              ], check=True)
+              branch = "spec-update-${{ github.run_number }}"
+              subprocess.run(["git", "checkout", "-b", branch], check=True)
+              subprocess.run(["git", "add", "specs/crypto.yaml"], check=True)
+              subprocess.run([
+                  "git",
+                  "commit",
+                  "-m",
+                  "chore: update crypto spec",
+              ], check=True)
+              subprocess.run(["git", "push", "origin", branch], check=True)
+              create_pull_request(
+                  title="Update crypto spec",
+                  body="Спецификация обновлена автоматически на основе новых данных с TradingView /metainfo",
+              )
+          PY
+

--- a/codex_actions.py
+++ b/codex_actions.py
@@ -112,7 +112,10 @@ def bump_version():
     print(f"Version bumped to {new_version}")
 
 
-def create_pull_request():
+def create_pull_request(
+    title: str = "Update OpenAPI specs",
+    body: str = "Automated specification update",
+):
     """Open a pull request using the GitHub CLI."""
     try:
         subprocess.run(
@@ -121,9 +124,9 @@ def create_pull_request():
                 "pr",
                 "create",
                 "--title",
-                "Update OpenAPI specs",
+                title,
                 "--body",
-                "Automated specification update",
+                body,
             ],
             check=True,
         )


### PR DESCRIPTION
## Summary
- update `daily-specs.yml` to open pull requests instead of pushing directly to `main`
- add workflow `generate-specs.yml` that runs `codex_actions` helpers and creates PRs
- extend `create_pull_request()` allowing customizable title and body

## Testing
- `pytest -q`
- `python - <<'PY'
from codex_actions import generate_openapi_spec, validate_spec

generate_openapi_spec()
validate_spec()
PY`

------
https://chatgpt.com/codex/tasks/task_e_684b3968ff8c832cab0f21329a6a12ef