### PR TITLE
Improve spec workflows

### DIFF
--- a/.github/workflows/daily-specs.yml
+++ b/.github/workflows/daily-specs.yml
@@ -52,6 +52,13 @@ jobs:
           git add results/** specs/coin.yaml
           git commit -m 'chore: update coin spec'
           git push origin "$branch"
-          gh pr create --title 'Update coin spec' --body 'Спецификация обновлена автоматически на основе новых данных с TradingView /metainfo'
+          python - <<'PY'
+          from codex_actions import create_pull_request
+
+          create_pull_request(
+              title="Update coin spec",
+              body="Спецификация обновлена автоматически на основе новых данных с TradingView /metainfo",
+          )
+          PY
       - name: Finish
         run: exit 0

--- a/.github/workflows/generate-specs.yml
+++ b/.github/workflows/generate-specs.yml
@@ -47,12 +47,16 @@ jobs:
           format_code()
           bump_version()
 
-          res = subprocess.run([
-              "git",
-              "diff",
-              "--quiet",
-              "specs/crypto.yaml",
-          ])
+          res = subprocess.run(
+              [
+                  "git",
+                  "diff",
+                  "--quiet",
+                  "HEAD",
+                  "--",
+                  "specs/crypto.yaml",
+              ]
+          )
           if res.returncode == 0:
               print("No spec changes detected")
           else:


### PR DESCRIPTION
## Summary
- trigger PR creation in daily-specs via codex helper
- refine diff check in generate-specs

## Testing
- `pytest -q`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684b3a70c1f4832c8dce867f00a4ef98