### PR TITLE
Add additional CLI tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.7
+- Version bump
 ## 1.0.6
 - Version bump
 ## 1.0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.6
+  version: 1.0.7
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -1,0 +1,157 @@
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from src.cli import cli
+from src.cli import collect_full as collect_full_cmd
+
+
+def _create_metainfo(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "data": {
+            "fields": [
+                {"name": "close", "type": "integer"},
+                {"name": "open", "type": "text"},
+            ]
+        }
+    }
+    path.write_text(json.dumps(data))
+    scan = {"count": 1, "data": [{"s": "AAA", "d": [1, "a"]}]}
+    (path.parent / "scan.json").write_text(json.dumps(scan))
+    tsv = (
+        "field\ttv_type\tstatus\tsample_value\n"
+        "close\tinteger\tok\t1\n"
+        "open\ttext\tok\ta\n"
+    )
+    (path.parent / "field_status.tsv").write_text(tsv)
+
+
+def _mock_collect_api(monkeypatch) -> None:
+    meta = {
+        "fields": [
+            {"name": "close", "type": "integer"},
+            {"name": "open", "type": "text"},
+        ],
+        "index": {"names": ["AAA", "BBB"]},
+    }
+
+    def fake_meta(scope: str) -> dict:
+        return meta
+
+    def fake_scan(scope: str, tickers: list[str], columns: list[str]) -> dict:
+        return {
+            "count": 2,
+            "data": [
+                {"s": tickers[0], "d": [1, "a"]},
+                {"s": tickers[1] if len(tickers) > 1 else tickers[0], "d": [2, "b"]},
+            ],
+        }
+
+    monkeypatch.setattr("src.cli.fetch_metainfo", fake_meta)
+    monkeypatch.setattr("src.cli.full_scan", fake_scan)
+    monkeypatch.setattr(
+        "src.cli.save_json", lambda d, p: Path(p).write_text(json.dumps(d))
+    )
+
+
+ASSETS = Path(__file__).parent / "assets"
+
+
+def test_generate_no_placeholder() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        market_dir = Path("results") / "coin"
+        _create_metainfo(market_dir / "metainfo.json")
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "--market",
+                "coin",
+                "--indir",
+                str(Path("results")),
+                "--outdir",
+                str(Path(".")),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        text = Path("coin.yaml").read_text()
+        assert "PLACEHOLDER" not in text
+        assert "TODO" not in text
+
+
+def test_generate_invalid_market() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["generate", "--market", "bad"])
+    assert result.exit_code != 0
+    assert "Invalid value for '--market'" in result.output
+
+
+def test_collect_full_and_generate(monkeypatch) -> None:
+    runner = CliRunner()
+    _mock_collect_api(monkeypatch)
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["collect-full", "--market", "crypto"])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(
+            cli,
+            ["generate", "--market", "crypto", "--indir", "results", "--outdir", "."],
+        )
+        assert result.exit_code == 0, result.output
+        text = Path("crypto.yaml").read_text()
+        assert "PLACEHOLDER" not in text
+        assert "TODO" not in text
+
+
+def test_collect_full_invalid_market() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["collect-full", "--market", "bad"])
+    assert result.exit_code != 0
+    assert "Invalid value for '--market'" in result.output
+
+
+def test_build(monkeypatch) -> None:
+    runner = CliRunner()
+    _mock_collect_api(monkeypatch)
+    monkeypatch.setattr("src.constants.SCOPES", ["coin"])
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["build"])
+        assert result.exit_code == 0, result.output
+        spec = Path("specs/coin.yaml")
+        assert spec.exists()
+        text = spec.read_text()
+        assert "PLACEHOLDER" not in text
+        assert "TODO" not in text
+
+
+def test_build_error(monkeypatch) -> None:
+    runner = CliRunner()
+    monkeypatch.setattr("src.constants.SCOPES", ["coin"])
+
+    def boom(*_a, **_kw):
+        raise click.ClickException("fail")
+
+    monkeypatch.setattr(collect_full_cmd, "callback", boom)
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["build"])
+        assert result.exit_code != 0
+
+
+def test_preview() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        spec = Path("spec.yaml")
+        spec.write_text((ASSETS / "prefinal.yaml").read_text())
+        result = runner.invoke(cli, ["preview", "--spec", str(spec)])
+        assert result.exit_code == 0, result.output
+        assert "field" in result.output
+        assert "close" in result.output
+
+
+def test_preview_missing() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["preview", "--spec", "missing.yaml"])
+    assert result.exit_code != 0
+    assert "No such file" in result.output

--- a/tests/test_yaml_generator_large.py
+++ b/tests/test_yaml_generator_large.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import yaml
+from src.generator.yaml_generator import generate_yaml
+from src.models import MetaInfoResponse, TVField
+
+
+def test_generate_yaml_large() -> None:
+    fields = []
+    types = ["number", "text", "bool", "time", "array"]
+    for i in range(120):
+        fields.append(TVField(name=f"f{i}", type=types[i % len(types)]))
+    meta = MetaInfoResponse(data=fields)
+    tsv = pd.DataFrame(columns=["field", "tv_type", "status", "sample_value"])
+    yaml_str = generate_yaml("coin", meta, tsv, None)
+    data = yaml.safe_load(yaml_str)
+
+    schemas = data["components"]["schemas"]
+    assert all(ref in schemas for ref in ["Num", "Str", "Bool", "Time", "Array"])
+
+    fields_schema = data["components"]["schemas"]["CoinFields"]
+    if "properties" in fields_schema:
+        props = fields_schema["properties"]
+    else:
+        props = {}
+        for part in fields_schema.get("allOf", []):
+            ref = part["$ref"].split("/")[-1]
+            props.update(schemas[ref]["properties"])
+    assert len(props) >= 100
+    assert len(props) == len(set(props))
+    for v in props.values():
+        assert "$ref" in v


### PR DESCRIPTION
## Summary
- add CLI coverage for build and preview commands
- add generator stress test for many fields
- bump version to 1.0.7

## Testing
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --market crypto --indir results --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684b4109a370832c9c5b51455aaba516