### PR TITLE
Fix unused imports and missing click import

### DIFF
--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, TYPE_CHECKING, Iterable
+from typing import Any, Dict, TYPE_CHECKING
 
 import toml
 import yaml

--- a/src/models.py
+++ b/src/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast, ClassVar, Literal
+from typing import Any, cast, Literal
 
 from pydantic import BaseModel, Field, constr, confloat, AliasChoices
 

--- a/tests/test_additional_coverage.py
+++ b/tests/test_additional_coverage.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from typing import Any
 

--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import click
 from click.testing import CliRunner
 
 from src.cli import cli


### PR DESCRIPTION
## Summary
- clean up unused imports
- ensure click is imported for CLI tests
- remove unused json import

## Testing
- `ruff check`
- `python - <<'PY'
import codex_actions
codex_actions.generate_openapi_spec()
PY`
- `python - <<'PY'
import codex_actions
codex_actions.validate_spec()
PY`
- `python - <<'PY'
import codex_actions
codex_actions.run_tests()
PY`


------
https://chatgpt.com/codex/tasks/task_e_684b571d17a8832ca41672446b6dcbd9