### PR TITLE
Remove respx dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.9
+- Version bump
 ## 1.0.8
 - Version bump
 ## 1.0.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ pydantic>=2.7
 types-requests
 types-PyYAML
 types-toml
-respx

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.8
+  version: 1.0.9
 servers:
   - url: https://scanner.tradingview.com
 paths:


### PR DESCRIPTION
## Summary
- remove `respx` from requirements
- bump version to 1.0.9

## Testing
- `python - <<'PY'
import codex_actions as ca
ca.generate_openapi_spec()
ca.validate_spec()
ca.run_tests()
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684b572059b4832c8dea6e0abc453819