### PR TITLE
Fix type hints and CLI handling

### DIFF
--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -133,8 +133,8 @@ def generate_yaml(
         "Time": {"type": "string", "format": "date-time"},
         "Array": {"type": "array", "items": {}},
     }
-    for name, schema in base.items():
-        openapi["components"]["schemas"].setdefault(name, schema)
+    for name, base_schema in base.items():
+        openapi["components"]["schemas"].setdefault(name, base_schema)
 
     openapi["components"]["schemas"]["NumericFieldNoTimeframe"] = {
         "type": "string",

--- a/src/models.py
+++ b/src/models.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any, cast, ClassVar, Literal
 
-from pydantic import BaseModel, Field, constr, confloat, AliasChoices
+from typing import Annotated
+
+from pydantic import BaseModel, Field, constr, confloat, AliasChoices, StringConstraints
 
 # Accepted TradingView field types
 FieldType = Literal[
@@ -37,10 +39,12 @@ class TVBaseModel(BaseModel):
 class TVField(TVBaseModel):
     """TradingView field description."""
 
-    n: constr(strip_whitespace=True, min_length=1) = Field(alias="name")
+    n: Annotated[str, constr(strip_whitespace=True, min_length=1)] = Field(alias="name")
     t: FieldType = Field(alias="type")
-    interval: confloat(gt=0) | None = None
-    description: constr(strip_whitespace=True, min_length=1) | None = None
+    interval: Annotated[float, confloat(gt=0)] | None = None
+    description: Annotated[str, constr(strip_whitespace=True, min_length=1)] | None = (
+        None
+    )
     flags: list[str] | None = None
 
 
@@ -71,7 +75,7 @@ class MetaInfoResponse(TVBaseModel):
 class ScanItem(TVBaseModel):
     """Single scan item."""
 
-    s: constr(strip_whitespace=True, min_length=1)
+    s: Annotated[str, constr(strip_whitespace=True, min_length=1)]
     d: list[object]
 
 


### PR DESCRIPTION
## Summary
- use `Annotated` forms for constrained strings and floats
- validate TVField creation in CLI
- guard CLI `.callback` access
- handle missing package version gracefully
- tweak YAML generator to avoid mypy issue

## Testing
- `PYTHONPATH=. pytest -q`
- `python -m src.cli generate --market crypto --indir results --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684b5721fea4832ca43f2653f5b6e2b8