### PR TITLE
Fix CLI additional test import

### DIFF
--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import click
 
 from click.testing import CliRunner
 


### PR DESCRIPTION
## Summary
- add missing click import in tests/test_cli_additional.py

## Testing
- `python - <<'PY'
from codex_actions import generate_openapi_spec, validate_spec, run_tests
generate_openapi_spec()
validate_spec()
run_tests()
PY`

------
https://chatgpt.com/codex/tasks/task_e_684b5723a2dc832cb58211e2e2d3dd8d