### PR TITLE
Update CI for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black flake8 mypy pytest openapi-spec-validator requests_mock \
+          pip install black flake8 mypy pytest pytest-cov openapi-spec-validator requests_mock \
             types-requests types-PyYAML types-toml -r requirements.txt
           pip install -e .
       - name: Format
@@ -32,8 +32,15 @@ jobs:
         run: flake8 .
       - name: Type check
         run: mypy --strict src/
-      - name: Test
-        run: pytest -q
+      - name: Test with coverage
+        run: pytest --cov=src --cov-report=xml --cov-fail-under=95 -q
+      - name: Upload coverage to Codecov
+        if: ${{ env.CODECOV_TOKEN != '' }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          pip install codecov
+          codecov -t $CODECOV_TOKEN
       - name: Generate specs for all markets
         run: |
           for market in crypto forex stocks futures; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.9
+- Version bump
 ## 1.0.8
 - Version bump
 ## 1.0.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.8
+  version: 1.0.9
 servers:
   - url: https://scanner.tradingview.com
 paths:


### PR DESCRIPTION
## Summary
- enforce 95% coverage in the CI workflow
- bump version to 1.0.9

## Testing
- `pytest -q`
- `pytest --cov=src --cov-report=term --cov-fail-under=95 -q`

------
https://chatgpt.com/codex/tasks/task_e_684b57257fa0832c87fa27c6f1819908