### PR TITLE
Fix CI Python constraints and quoting

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -49,7 +49,7 @@ jobs:
           if [ -n "$SERVER_URL" ]; then
             extra="--server-url $SERVER_URL"
           fi
-          poetry run tvgen collect-full --outdir results $extra
+          poetry run tvgen collect-full --outdir results "$extra"
       - name: Generate specs for all markets
         run: |
           extra=""
@@ -57,7 +57,7 @@ jobs:
             extra="--server-url $SERVER_URL"
           fi
           for market in crypto forex stocks futures; do
-            tvgen generate --market $market --output specs/openapi_${market}.yaml $extra  # yamllint disable-line rule:line-length
+            tvgen generate --market $market --output specs/openapi_${market}.yaml "$extra"  # yamllint disable-line rule:line-length
           done
       - name: Validate all generated specs
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.10
+- Version bump
 ## 1.0.9
 - Version bump
 ## 1.0.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.9"
+version = "1.0.10"
+requires-python = ">=3.9"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pydantic>=2.7
 types-requests
 types-PyYAML
 types-toml
+pytest

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.9
+  version: 1.0.10
 servers:
   - url: https://scanner.tradingview.com
 paths:


### PR DESCRIPTION
## Summary
- require Python >=3.9 for pandas compatibility
- install pytest via requirements.txt
- quote `$extra` args in spec-update workflow
- bump version to 1.0.10 and regenerate crypto spec

## Testing
- `black .`
- `python - <<'PY'
from codex_actions import generate_openapi_spec, validate_spec, run_tests

generate_openapi_spec()
validate_spec()
run_tests()
PY`

------
https://chatgpt.com/codex/tasks/task_e_684b5d972d00832c987d4a8e8a03091d