### PR TITLE
Fix build by updating Python requirement and installing black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tv-generator"
 version = "1.0.10"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ types-requests
 types-PyYAML
 types-toml
 pytest
+black


### PR DESCRIPTION
## Summary
- require Python 3.10+ to match `click`
- install `black` via `requirements.txt`

## Testing
- `black .`
- `python - <<'PY'
from codex_actions import generate_openapi_spec, validate_spec, run_tests

generate_openapi_spec()
validate_spec()
run_tests()
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684b6f992f28832cbd665f2d7be5cf64