### PR TITLE
Fix Python version check and bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.11
+- Version bump
 ## 1.0.10
 - Version bump
 ## 1.0.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.10"
-requires-python = ">=3.9"
+version = "1.0.11"
+requires-python = ">=3.10,<3.12"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ types-requests
 types-PyYAML
 types-toml
 pytest
+black

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.10
+  version: 1.0.11
 servers:
   - url: https://scanner.tradingview.com
 paths:


### PR DESCRIPTION
## Summary
- enforce Python 3.10 to 3.11 range
- bundle black as a required dependency
- bump version to keep spec in sync

## Testing
- `format_code`
- `generate_openapi_spec`
- `validate_spec`
- `run_tests`


------
https://chatgpt.com/codex/tasks/task_e_684b6f992f28832cbd665f2d7be5cf64