### PR TITLE
Fix tvgen path in CI workflows

### DIFF
--- a/.github/workflows/daily-specs.yml
+++ b/.github/workflows/daily-specs.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install --no-interaction --no-root
+      - name: Debug tvgen installation
+        run: |
+          poetry run tvgen --help || echo "tvgen is not installed or not in PATH"
       - name: Collect full data
         run: poetry run tvgen collect-full --scope coin
       - name: Generate spec

--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -35,10 +35,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install requests_mock yamllint openapi-spec-validator \
+          pip install poetry
+          poetry install --no-interaction --no-root
+          poetry run pip install requests_mock yamllint openapi-spec-validator \
             types-requests types-PyYAML types-toml
-          pip install -e .
+      - name: Debug tvgen installation
+        run: |
+          poetry run tvgen --help || echo "tvgen is not installed or not in PATH"
       - name: Export server URL
         if: env.SERVER_URL != ''
         run: echo "SERVER_URL=${SERVER_URL}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- ensure Poetry installs `tvgen` before calling it in `spec-update.yml`
- add a debug step in CI workflows to check the `tvgen` command

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7593e66c832c93e5b25522b777b2