### PR TITLE
Fix lint errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.12
+- Version bump
 ## 1.0.11
 - Version bump
 ## 1.0.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.11"
+version = "1.0.12"
 requires-python = ">=3.10,<3.12"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -46,7 +46,7 @@ def _indicator_name(raw: str) -> str:
     for key, val in _INDICATOR_NAMES.items():
         if raw.startswith(key):
             if key == "EMA" and raw != "EMA":
-                period = raw[len("EMA") :]
+                period = raw[len("EMA"):]
                 if period.isdigit():
                     return f"{val} ({period})"
             return val

--- a/src/models.py
+++ b/src/models.py
@@ -4,7 +4,7 @@ from typing import Any, cast, Literal
 
 from typing import Annotated
 
-from pydantic import BaseModel, Field, constr, confloat, AliasChoices, StringConstraints
+from pydantic import BaseModel, Field, constr, confloat, AliasChoices
 
 # Accepted TradingView field types
 FieldType = Literal[

--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -1,8 +1,6 @@
 import json
 from pathlib import Path
 import click
-
-import click
 from click.testing import CliRunner
 
 from src.cli import cli


### PR DESCRIPTION
## Summary
- remove unused import
- fix whitespace in YAML generator
- deduplicate click import in tests
- bump version to 1.0.12

## Testing
- `python - <<'PY'
import codex_actions
codex_actions.generate_openapi_spec()
codex_actions.validate_spec()
codex_actions.run_tests()
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684b7700e468832c9775ef4cada36d79