### PR TITLE
Fix formatting issues in yaml_generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.13
+- Version bump
 ## 1.0.12
 - Version bump
 ## 1.0.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.12"
+version = "1.0.13"
 requires-python = ">=3.10,<3.12"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.11
+  version: 1.0.13
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -46,7 +46,7 @@ def _indicator_name(raw: str) -> str:
     for key, val in _INDICATOR_NAMES.items():
         if raw.startswith(key):
             if key == "EMA" and raw != "EMA":
-                period = raw[len("EMA"):]
+                period = raw[len("EMA") :]
                 if period.isdigit():
                     return f"{val} ({period})"
             return val


### PR DESCRIPTION
## Summary
- run `black` on src/generator/yaml_generator.py
- bump version to 1.0.13
- regenerate `specs/crypto.yaml`

## Testing
- `python - <<'PY'
import codex_actions as a
try:
    a.generate_openapi_spec()
except Exception as e:
    print('generate_openapi_spec failed', e)
PY`
- `python - <<'PY'
import codex_actions as a
try:
    a.validate_spec()
except Exception as e:
    print('validate_spec failed', e)
PY`
- `python - <<'PY'
import codex_actions as a
try:
    a.run_tests()
except Exception as e:
    print('run_tests failed', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_684b789d9914832c95492d19be1b0255