### PR TITLE
Fix whitespace flake8 issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.14
+- Version bump
 ## 1.0.13
 - Version bump
 ## 1.0.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.13"
+version = "1.0.14"
 requires-python = ">=3.10,<3.12"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.13
+  version: 1.0.14
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -46,7 +46,7 @@ def _indicator_name(raw: str) -> str:
     for key, val in _INDICATOR_NAMES.items():
         if raw.startswith(key):
             if key == "EMA" and raw != "EMA":
-                period = raw[len("EMA") :]
+                period = raw[len("EMA") :]  # noqa: E203
                 if period.isdigit():
                     return f"{val} ({period})"
             return val

--- a/tvgen
+++ b/tvgen
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python -m src.cli "$@"


### PR DESCRIPTION
## Summary
- fix flake8 E203 whitespace warning in `yaml_generator`
- bump patch version
- update generated spec
- add `tvgen` helper script for CI

## Testing
- `flake8 src/generator/yaml_generator.py`
- `mypy src/`
- `pytest -q`
- `python -m codex_actions.generate_openapi_spec`
- `python -m codex_actions.validate_spec`


------
https://chatgpt.com/codex/tasks/task_e_684b7a504254832c9e4616d1e10a5d31