### PR TITLE
Fix CI Python matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- drop Python 3.12 from CI matrix to match supported versions

## Testing
- `PYTHONPATH=. python src/cli.py generate --market crypto --outdir specs`
- `PYTHONPATH=. python src/cli.py validate --spec specs/crypto.yaml`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7bdf4a80832c902c02c29135f0f8