### PR TITLE
Fix typing annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.15
+- Version bump
 ## 1.0.14
 - Version bump
 ## 1.0.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.14"
+version = "1.0.15"
 requires-python = ">=3.10,<3.12"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/src/api/data_manager.py
+++ b/src/api/data_manager.py
@@ -3,7 +3,7 @@ from typing import Any
 from src.models import MetaInfoResponse
 
 
-def build_field_status(meta: MetaInfoResponse, scan: dict) -> pd.DataFrame:
+def build_field_status(meta: MetaInfoResponse, scan: dict[str, Any]) -> pd.DataFrame:
     """Return DataFrame summarizing scan results for each field.
 
     The returned frame has exactly four columns in this order:

--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -64,7 +64,7 @@ def generate_yaml(
     scope: str,
     meta: MetaInfoResponse,
     _tsv: "pd.DataFrame",
-    scan: dict | None = None,
+    scan: dict[str, Any] | None = None,
     server_url: str = "https://scanner.tradingview.com",
     max_size: int = 1_048_576,
 ) -> str:


### PR DESCRIPTION
## Summary
- fix incorrect typing and remove stale comment
- explicitly type generic params for YAML and data fetch helpers
- bump patch version

## Testing
- `python -m src.cli generate --market crypto --indir results --outdir specs --max-size 1048576`
- `python -m src.cli validate --spec specs/crypto.yaml`
- `pytest -q`
- `flake8 .`
- `mypy src/`

------
https://chatgpt.com/codex/tasks/task_e_684b7d32b5a8832cbcdd1d4fb75cfaec