### PR TITLE
Fix Docker tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,5 +36,5 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/tvgen:latest
+          tags: ghcr.io/${{ github.repository_owner | toLower }}/tvgen:latest
           provenance: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.16
+- Version bump
 ## 1.0.15
 - Version bump
 ## 1.0.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.15"
+version = "1.0.16"
 requires-python = ">=3.10,<3.12"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.14
+  version: 1.0.15
 servers:
   - url: https://scanner.tradingview.com
 paths:


### PR DESCRIPTION
## Summary
- lower case repository owner in docker push tags
- bump version to 1.0.16

## Testing
- `python -m src.cli generate --market crypto --indir results --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`
- `pytest -q` *(fails: 17 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b7f03c708832c893e1f9ecd96b42d