### PR TITLE
Update CI Python support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.17
+- Version bump
 ## 1.0.16
 - Version bump
 ## 1.0.15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.16"
-requires-python = ">=3.10,<3.12"
+version = "1.0.17"
+requires-python = ">=3.10,<3.13"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 
 [project.scripts]

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.15
+  version: 1.0.17
 servers:
   - url: https://scanner.tradingview.com
 paths:


### PR DESCRIPTION
## Summary
- allow Python 3.12 in `pyproject.toml`
- bump version to 1.0.17
- regenerate `specs/crypto.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b801b6838832ca995a5ea54de3e5a