### PR TITLE
Fix CI indentation and coverage condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,19 +35,20 @@ jobs:
       - name: Test with coverage
         run: pytest --cov=src --cov-report=xml --cov-fail-under=95 -q
       - name: Upload coverage to Codecov
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           pip install codecov
           codecov -t $CODECOV_TOKEN
-       - name: Generate specs for all markets
-         run: |
-           for market in crypto forex stocks futures; do
-             mkdir -p results/$market
-             echo -e "field\tstatus\tvalue\nclose\tok\t1\nopen\tok\tabc" > results/$market/field_status.tsv
-             tvgen generate --market $market --outdir specs/openapi_${market}.yaml
-           done
+      - name: Generate specs for all markets
+        run: |
+          mkdir -p specs
+          for market in crypto forex stocks futures; do
+            mkdir -p results/$market
+            echo -e "field\tstatus\tvalue\nclose\tok\t1\nopen\tok\tabc" > results/$market/field_status.tsv
+            tvgen generate --market $market --outdir specs/openapi_${market}.yaml
+          done
 
       - name: Validate all generated specs
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.18
+- Version bump
 ## 1.0.17
 - Version bump
 ## 1.0.16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.17"
+version = "1.0.18"
 requires-python = ">=3.10,<3.13"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.17
+  version: 1.0.18
 servers:
   - url: https://scanner.tradingview.com
 paths:


### PR DESCRIPTION
## Summary
- correct indentation in CI workflow
- ensure Codecov step runs correctly
- create specs folder in workflow if missing
- bump version to 1.0.18

## Testing
- `black .`
- `pytest -q`
- `python - <<'PY'
from codex_actions import generate_openapi_spec, validate_spec
generate_openapi_spec()
validate_spec()
PY`


------
https://chatgpt.com/codex/tasks/task_e_684b811e4ec4832c8859a0d88972c37a