### PR TITLE
Fix CI coverage condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
       - name: Test with coverage
         run: pytest --cov=src --cov-report=xml --cov-fail-under=95 -q
       - name: Upload coverage to Codecov
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         run: |
           pip install codecov
           codecov -t $CODECOV_TOKEN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.19
+- Version bump
 ## 1.0.18
 - Version bump
 ## 1.0.17

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.18"
+version = "1.0.19"
 requires-python = ">=3.10,<3.13"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.18
+  version: 1.0.19
 servers:
   - url: https://scanner.tradingview.com
 paths:


### PR DESCRIPTION
## Summary
- adjust Codecov step condition in CI workflow
- bump version to 1.0.19
- update generated crypto OpenAPI spec

## Testing
- `black .`
- `pytest -q`
- `tvgen validate --spec specs/openapi_crypto.yaml` *(fails: IsADirectoryError)*
- `tvgen validate --spec specs/openapi_crypto.yaml/crypto.yaml`
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684b83d5676c832cb01788d937bce20e