### PR TITLE
Fix CI by generating metainfo files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,15 @@ jobs:
         run: |
           pip install codecov
           codecov -t $CODECOV_TOKEN
-      - name: Generate specs for all markets
-        run: |
-          mkdir -p specs
-          for market in crypto forex stocks futures; do
-            mkdir -p results/$market
-            echo -e "field\tstatus\tvalue\nclose\tok\t1\nopen\tok\tabc" > results/$market/field_status.tsv
-            tvgen generate --market $market --outdir specs/openapi_${market}.yaml
-          done
+        - name: Generate specs for all markets
+          run: |
+            mkdir -p specs
+            for market in crypto forex stocks futures; do
+              mkdir -p results/$market
+              echo -e "field\tstatus\tvalue\nclose\tok\t1\nopen\tok\tabc" > results/$market/field_status.tsv
+              echo '{ "market": "'$market'", "info": "Generated metadata" }' > results/$market/metainfo.json
+              tvgen generate --market $market --outdir specs/openapi_${market}.yaml
+            done
 
       - name: Validate all generated specs
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.20
+- Version bump
 ## 1.0.19
 - Version bump
 ## 1.0.18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.19"
+version = "1.0.20"
 requires-python = ">=3.10,<3.13"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 


### PR DESCRIPTION
## Summary
- create `metainfo.json` for every market in CI
- bump version to 1.0.20

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b8553c848832c8c5ed3af770d2a1d