### PR TITLE
Ignore symbol field in YAML generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.25
+- Version bump
 ## 1.0.24
 - Version bump
 ## 1.0.23

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.24"
+version = "1.0.25"
 requires-python = ">=3.10,<3.13"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.23
+  version: 1.0.25
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -81,6 +81,8 @@ def generate_yaml(
         flags = set(field.flags or [])
         if {"deprecated", "private"} & flags:
             continue
+        if field.n.lower() in {"symbol", "s"}:
+            continue
         schema: Dict[str, Any] = {"$ref": tv2ref(field.t)}
         schema["description"] = _describe_field(field.n)
 

--- a/tests/test_yaml_generator.py
+++ b/tests/test_yaml_generator.py
@@ -56,3 +56,18 @@ def test_numeric_field_components() -> None:
     schemas = data["components"]["schemas"]
     assert schemas["NumericFieldNoTimeframe"]["enum"] == ["RSI"]
     assert "pattern" in schemas["NumericFieldWithTimeframe"]
+
+
+def test_symbol_field_ignored() -> None:
+    meta = MetaInfoResponse(
+        data=[
+            TVField(name="symbol", type="string"),
+            TVField(name="close", type="integer"),
+        ]
+    )
+    tsv = pd.DataFrame()
+    yaml_str = generate_yaml("crypto", meta, tsv, None)
+    data = yaml.safe_load(yaml_str)
+    props = data["components"]["schemas"]["CryptoFields"]["properties"]
+    assert "symbol" not in props
+    assert "close" in props


### PR DESCRIPTION
## Summary
- skip symbol fields when building YAML schema
- add regression test to ensure symbol is excluded
- bump version to 1.0.25 and regenerate crypto spec

## Testing
- `mypy src/`
- `pytest -q`
- `python - <<'PY'
import codex_actions as c
c.generate_openapi_spec()
PY`
- `python - <<'PY'
import codex_actions as c
c.validate_spec()
PY`


------
https://chatgpt.com/codex/tasks/task_e_684bf8cba29c832cbfe60866b7ea08e7