### PR TITLE
Automate multi-market spec generation

### DIFF
--- a/.github/workflows/daily-specs.yml
+++ b/.github/workflows/daily-specs.yml
@@ -32,34 +32,38 @@ jobs:
       - name: Debug tvgen installation
         run: |
           poetry run tvgen --help || echo "tvgen is not installed or not in PATH"
-      - name: Collect full data
-        run: poetry run tvgen collect-full --scope coin
-      - name: Generate spec
-        run: poetry run tvgen generate --scope coin
-      - name: Validate generated spec
-        run: openapi-spec-validator specs/coin.yaml
+      - name: Build specs
+        run: poetry run tvgen build --indir results --outdir specs
+      - name: Validate generated specs
+        run: |
+          for spec in specs/*.yaml; do
+            openapi-spec-validator "$spec"
+          done
       - name: Check size limit
-        run: python -c "import os,sys; s=os.path.getsize('specs/coin.yaml'); assert s<1048576"
+        run: |
+          for spec in specs/*.yaml; do
+            python -c "import os,sys; s=os.path.getsize('$spec'); assert s<1048576"
+          done
       - name: Commit and create PR if spec changed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          if git diff --quiet HEAD -- specs/coin.yaml; then
+          if git diff --quiet HEAD -- specs/*.yaml; then
             echo "No changes detected"
             exit 0
           fi
-          branch="coin-spec-${{ github.run_number }}"
+          branch="specs-${{ github.run_number }}"
           git checkout -b "$branch"
-          git add results/** specs/coin.yaml
-          git commit -m 'chore: update coin spec'
+          git add results/** specs/*.yaml
+          git commit -m 'chore: update specs'
           git push origin "$branch"
           python - <<'PY'
           from codex_actions import create_pull_request
 
           create_pull_request(
-              title="Update coin spec",
+              title="Update OpenAPI specs",
               body="Спецификация обновлена автоматически на основе новых данных с TradingView /metainfo",
           )
           PY

--- a/.github/workflows/generate-specs.yml
+++ b/.github/workflows/generate-specs.yml
@@ -49,14 +49,7 @@ jobs:
           bump_version()
 
           res = subprocess.run(
-              [
-                  "git",
-                  "diff",
-                  "--quiet",
-                  "HEAD",
-                  "--",
-                  "specs/crypto.yaml",
-              ]
+              ["git", "diff", "--quiet", "HEAD", "--", "specs/*.yaml"]
           )
           if res.returncode == 0:
               print("No spec changes detected")
@@ -75,16 +68,16 @@ jobs:
               ], check=True)
               branch = "spec-update-${{ github.run_number }}"
               subprocess.run(["git", "checkout", "-b", branch], check=True)
-              subprocess.run(["git", "add", "specs/crypto.yaml"], check=True)
+              subprocess.run(["git", "add", "specs/*.yaml"], check=True)
               subprocess.run([
                   "git",
                   "commit",
                   "-m",
-                  "chore: update crypto spec",
+                  "chore: update specs",
               ], check=True)
               subprocess.run(["git", "push", "origin", branch], check=True)
               create_pull_request(
-                  title="Update crypto spec",
+                  title="Update OpenAPI specs",
                   body="Спецификация обновлена автоматически на основе новых данных с TradingView /metainfo",
               )
           PY

--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -46,25 +46,16 @@ jobs:
         if: env.SERVER_URL != ''
         run: echo "SERVER_URL=${SERVER_URL}" >> "$GITHUB_ENV"
 
-      - name: Collect full data
+      - name: Build specs
         run: |
           extra=""
           if [ -n "$SERVER_URL" ]; then
             extra="--server-url $SERVER_URL"
           fi
-          poetry run tvgen collect-full --outdir results "$extra"
-      - name: Generate specs for all markets
-        run: |
-          extra=""
-          if [ -n "$SERVER_URL" ]; then
-            extra="--server-url $SERVER_URL"
-          fi
-          for market in crypto forex stocks futures; do
-            tvgen generate --market $market --output specs/openapi_${market}.yaml "$extra"  # yamllint disable-line rule:line-length
-          done
+          poetry run tvgen build --indir results --outdir specs $extra
       - name: Validate all generated specs
         run: |
-          for spec in specs/openapi_*.yaml; do
+          for spec in specs/*.yaml; do
             yamllint "$spec"
             openapi-spec-validator "$spec"
           done
@@ -90,7 +81,7 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           add: |
-            specs/openapi_*.yaml
+            specs/*.yaml
             results/**
           message: 'chore: update generated specifications'
           default_author: github_actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.26
+- Version bump
 ## 1.0.25
 - Version bump
 ## 1.0.24

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.25"
+version = "1.0.26"
 requires-python = ">=3.10,<3.13"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -139,6 +139,17 @@ def test_build_error(monkeypatch) -> None:
         assert result.exit_code != 0
 
 
+def test_build_parallel(monkeypatch) -> None:
+    runner = CliRunner()
+    _mock_collect_api(monkeypatch)
+    monkeypatch.setattr("src.constants.SCOPES", ["coin", "stocks"])
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["build", "--workers", "2"])
+        assert result.exit_code == 0, result.output
+        assert Path("specs/coin.yaml").exists()
+        assert Path("specs/stocks.yaml").exists()
+
+
 def test_preview() -> None:
     runner = CliRunner()
     with runner.isolated_filesystem():


### PR DESCRIPTION
## Summary
- add --workers option for `tvgen build` and expose as `build-all`
- generate specs for all markets in codex actions
- update GitHub workflows to use unified build
- test parallel build behavior
- bump version to 1.0.26

## Testing
- `black . --quiet`
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `python - <<'PY'`
  `from codex_actions import generate_openapi_spec, validate_spec`
  `generate_openapi_spec()`
  `validate_spec()`
  `PY` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684bfa1fe560832c8c2d6d40a783f74d