### PR TITLE
Fix daily workflow

### DIFF
--- a/.github/workflows/daily-specs.yml
+++ b/.github/workflows/daily-specs.yml
@@ -8,14 +8,11 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   build:
     permissions:
       contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,36 +47,26 @@ jobs:
           done
       - name: Validate generated specs
         run: |
+          shopt -s nullglob
           for spec in specs/*.yaml; do
             openapi-spec-validator "$spec"
           done
       - name: Check size limit
         run: |
+          shopt -s nullglob
           for spec in specs/*.yaml; do
             python -c "import os,sys; s=os.path.getsize('$spec'); assert s<1048576, 'Spec size exceeds 1MB!'"
           done
-      - name: Commit and create PR if spec changed
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          if git diff --quiet HEAD -- specs/*.yaml; then
-            echo "No changes detected"
-            exit 0
-          fi
-          branch="specs-${{ github.run_number }}"
-          git checkout -b "$branch"
-          git add results/** specs/*.yaml
-          git commit -m 'chore: update specs'
-          git push origin "$branch"
-          python - <<'PY'
-          from codex_actions import create_pull_request
-
-          create_pull_request(
-              title="Update OpenAPI specs",
-              body="Спецификация обновлена автоматически на основе новых данных с TradingView /metainfo",
-          )
-          PY
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: update specs'
+          branch: specs-${{ github.run_number }}
+          title: Update OpenAPI specs
+          body: "Спецификация обновлена автоматически на основе новых данных с TradingView /metainfo"
+          add-paths: |
+            results/**
+            specs/*.yaml
       - name: Finish
         run: exit 0

--- a/specs/america.yaml
+++ b/specs/america.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView America API
-  version: 1.0.30
+  version: 1.0.31
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/bond.yaml
+++ b/specs/bond.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Bond API
-  version: 1.0.30
+  version: 1.0.31
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/cfd.yaml
+++ b/specs/cfd.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Cfd API
-  version: 1.0.30
+  version: 1.0.31
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/coin.yaml
+++ b/specs/coin.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Coin API
-  version: 1.0.30
+  version: 1.0.31
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/forex.yaml
+++ b/specs/forex.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Forex API
-  version: 1.0.30
+  version: 1.0.31
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/futures.yaml
+++ b/specs/futures.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Futures API
-  version: 1.0.30
+  version: 1.0.31
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/stocks.yaml
+++ b/specs/stocks.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Stocks API
-  version: 1.0.30
+  version: 1.0.31
 servers:
   - url: https://scanner.tradingview.com
 paths:


### PR DESCRIPTION
## Summary
- simplify permissions in daily-specs workflow
- use `nullglob` when iterating over spec files
- switch to the `peter-evans/create-pull-request` action
- update generated specs

## Testing
- `pip install -r requirements.txt`
- `pip install types-requests types-PyYAML types-toml`
- `pip install -e .`
- `python - <<'PY'
from codex_actions import run_tests
run_tests()
PY`
- `python - <<'PY'
from codex_actions import generate_openapi_spec

generate_openapi_spec()
PY`
- `python - <<'PY'
from codex_actions import validate_spec

validate_spec()
PY`


------
https://chatgpt.com/codex/tasks/task_e_684ccd633a64832c8cf8eea4ed889a5b