### PR TITLE
Refactor collect command and improve scan errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           mkdir -p specs
           for market in crypto forex stocks futures; do
             mkdir -p results/$market
-            echo -e "field\tstatus\tvalue\nclose\tok\t1\nopen\tok\tabc" > results/$market/field_status.tsv
+            echo -e "field\ttv_type\tstatus\tsample_value\nclose\tinteger\tok\t1\nopen\tstring\tok\tabc" > results/$market/field_status.tsv
             echo '{ "market": "'$market'", "info": "Generated metadata" }' > results/$market/metainfo.json
             tvgen generate --market $market --outdir specs/openapi_${market}.yaml
             status=$?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Welcome! This document explains how to work with this repository when acting as 
 The typical workflow is:
 
 ```
-tvgen collect-full --market crypto
+tvgen collect --market crypto
  tvgen generate --market crypto --outdir specs
  tvgen validate --spec specs/crypto.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Using Poetry
 ```bash
 poetry install
-poetry run tvgen collect-full --market crypto
+poetry run tvgen collect --market crypto
 poetry run tvgen generate --market crypto
 poetry run tvgen validate --spec specs/crypto.yaml
 ```
@@ -25,7 +25,7 @@ The generation commands contact TradingView's public API. Ensure that `scanner.t
 ### Docker
 ```bash
 docker run --rm ghcr.io/<owner>/tvgen:latest \
-  tvgen collect-full --market crypto && \
+  tvgen collect --market crypto && \
   tvgen generate --market crypto
 ```
 
@@ -33,7 +33,7 @@ docker run --rm ghcr.io/<owner>/tvgen:latest \
 | Command      | Purpose                                   | Key Flags |
 |--------------|-------------------------------------------|-----------|
 | build        | collect+generate specs for all markets    | --indir • --outdir |
-| collect-full | download metainfo+scan, build TSV         | --market • --outdir • --tickers |
+| collect | download metainfo+scan, build TSV         | --market • --outdir • --tickers |
 | generate     | build OpenAPI spec                        | --market • --indir • --outdir • --max-size |
 | validate     | validate spec file                        | --spec |
 | preview      | show fields summary from spec             | --spec |
@@ -41,7 +41,7 @@ docker run --rm ghcr.io/<owner>/tvgen:latest \
 ### Short Examples
 ```bash
 # Collect metainfo and scan results
-tvgen collect-full --market crypto --outdir results
+tvgen collect --market crypto --outdir results
 
 # Generate specification from collected data
 tvgen generate --market crypto --indir results --outdir specs
@@ -51,7 +51,7 @@ tvgen validate --spec specs/crypto.yaml
 ```
 
 ## Daily CI Flow
-`collect-full` → `generate` → size-validate → commit
+`collect` → `generate` → size-validate → commit
 
 ## Field Name Format
 Indicators can include a timeframe suffix separated by `|`. For example `RSI|60` means the RSI value on a 60‑minute timeframe. `ADX+DI[1]|1D` refers to the `ADX+DI[1]` indicator on daily candles.

--- a/results/crypto/field_status.tsv
+++ b/results/crypto/field_status.tsv
@@ -1,3 +1,3 @@
-field	status	value
-close	ok	1
-open	ok	abc
+field	tv_type	status	sample_value
+close	integer	ok	1
+open	text	ok	abc

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -186,6 +186,7 @@ def test_cli_search_invalid_payload() -> None:
     )
     assert result.exit_code != 0
     assert result.exception is not None
+    assert "Expecting" in result.output
 
 
 def test_cli_history_invalid_payload() -> None:
@@ -387,11 +388,11 @@ def _mock_collect_api(monkeypatch) -> None:
     monkeypatch.setattr("src.cli.full_scan", fake_scan)
 
 
-def test_collect_full_success(monkeypatch):
+def test_collect_success(monkeypatch):
     runner = CliRunner()
     _mock_collect_api(monkeypatch)
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["collect-full", "--market", "crypto"])
+        result = runner.invoke(cli, ["collect", "--market", "crypto"])
         assert result.exit_code == 0
         base = Path("results/crypto")
         assert (base / "metainfo.json").exists()
@@ -402,15 +403,7 @@ def test_collect_full_success(monkeypatch):
         assert "open\tstring\tok\ta" in status_lines[2]
 
 
-def test_collect_full_alias(monkeypatch):
-    runner = CliRunner()
-    _mock_collect_api(monkeypatch)
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["collect", "--market", "crypto"])
-        assert result.exit_code == 0
-
-
-def test_collect_full_error(monkeypatch):
+def test_collect_error(monkeypatch):
     runner = CliRunner()
     monkeypatch.setattr(
         "src.cli.fetch_metainfo",
@@ -418,7 +411,7 @@ def test_collect_full_error(monkeypatch):
     )
     monkeypatch.setattr("src.cli.full_scan", lambda scope, tickers, columns: {})
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["collect-full", "--market", "crypto"])
+        result = runner.invoke(cli, ["collect", "--market", "crypto"])
         assert result.exit_code != 0
         log = Path("results/crypto/error.log").read_text()
         assert log

--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -4,7 +4,7 @@ import click
 from click.testing import CliRunner
 
 from src.cli import cli
-from src.cli import collect_full as collect_full_cmd
+from src.cli import collect as collect_cmd
 
 
 def _create_metainfo(path: Path) -> None:
@@ -89,11 +89,11 @@ def test_generate_invalid_market() -> None:
     assert "Invalid value for '--market'" in result.output
 
 
-def test_collect_full_and_generate(monkeypatch) -> None:
+def test_collect_and_generate(monkeypatch) -> None:
     runner = CliRunner()
     _mock_collect_api(monkeypatch)
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["collect-full", "--market", "crypto"])
+        result = runner.invoke(cli, ["collect", "--market", "crypto"])
         assert result.exit_code == 0, result.output
         result = runner.invoke(
             cli,
@@ -105,9 +105,9 @@ def test_collect_full_and_generate(monkeypatch) -> None:
         assert "TODO" not in text
 
 
-def test_collect_full_invalid_market() -> None:
+def test_collect_invalid_market() -> None:
     runner = CliRunner()
-    result = runner.invoke(cli, ["collect-full", "--market", "bad"])
+    result = runner.invoke(cli, ["collect", "--market", "bad"])
     assert result.exit_code != 0
     assert "Invalid value for '--market'" in result.output
 
@@ -133,7 +133,7 @@ def test_build_error(monkeypatch) -> None:
     def boom(*_a, **_kw):
         raise click.ClickException("fail")
 
-    monkeypatch.setattr(collect_full_cmd, "callback", boom)
+    monkeypatch.setattr(collect_cmd, "callback", boom)
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ["build"])
         assert result.exit_code != 0

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from src.cli import cli
 
 
-def test_collect_full(monkeypatch):
+def test_collect(monkeypatch):
     runner = CliRunner()
 
     meta = {
@@ -24,7 +24,7 @@ def test_collect_full(monkeypatch):
     monkeypatch.setattr("src.cli.save_json", lambda d, p: Path(p).write_text("{}"))
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["collect-full", "--market", "crypto"])
+        result = runner.invoke(cli, ["collect", "--market", "crypto"])
         assert result.exit_code == 0
         assert scan_args["tickers"] == ["AAA", "BBB"]
         assert scan_args["columns"] == ["c1"]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -36,7 +36,7 @@ def test_e2e_collect_and_generate(tmp_path, monkeypatch):
         out_dir = Path("tmp_res")
         result = runner.invoke(
             cli,
-            ["collect-full", "--market", "crypto", "--outdir", str(out_dir)],
+            ["collect", "--market", "crypto", "--outdir", str(out_dir)],
         )
         assert result.exit_code == 0
         market_dir = out_dir / "crypto"

--- a/tests/test_size_limit.py
+++ b/tests/test_size_limit.py
@@ -80,7 +80,7 @@ def test_collect_full_auto_tickers(monkeypatch) -> None:
     monkeypatch.setattr("src.cli.save_json", lambda d, p: Path(p).write_text("{}"))
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["collect-full", "--market", "coin"])
+        result = runner.invoke(cli, ["collect", "--market", "coin"])
         assert result.exit_code == 0, result.output
         assert len(sent["tickers"]) <= 10
 


### PR DESCRIPTION
## Summary
- rename `collect-full` command to `collect`
- log HTTP status details for scan errors
- convert legacy TSV files in codex_actions
- update docs and workflow data
- adjust CLI tests for new command

## Testing
- `black .`
- `python - <<'PY'
import codex_actions
codex_actions.generate_openapi_spec()
PY
`
- `python - <<'PY'
import codex_actions
codex_actions.validate_spec()
PY
`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cd5b603f4832c8e473de909b8120e