### PR TITLE
Improve field status tests and TSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.33
+- Version bump
 ## 1.0.32
 - Version bump
 ## 1.0.31

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.32"
+version = "1.0.33"
 requires-python = ">=3.10,<3.13"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.31
+  version: 1.0.32
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/src/cli.py
+++ b/src/cli.py
@@ -305,7 +305,8 @@ def collect(market: str, tickers: str, outdir: Path, offline: bool) -> None:
                 )
         meta_model = MetaInfoResponse(data=tv_fields)
         df = build_field_status(meta_model, scan)
-        df.to_csv(market_dir / "field_status.tsv", sep="\t", index=False)
+        tsv_text = df.to_csv(sep="\t", index=False)
+        (market_dir / "field_status.tsv").write_text(tsv_text.rstrip("\n"))
     except Exception as exc:  # pragma: no cover - click handles output
         error_log.write_text(str(exc))
         raise click.ClickException(str(exc))

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -33,3 +33,39 @@ def test_build_field_status_missing():
     scan = {"data": [{"d": [1]}, {"d": [2]}]}
     df = build_field_status(meta, scan)
     assert list(df["status"]) == ["ok", "error"]
+
+
+def test_build_field_status_full_ok():
+    meta = _meta([("f1", "integer"), ("f2", "string")])
+    scan = {"data": [{"d": [1, "a"]}, {"d": [2, "b"]}]}
+    df = build_field_status(meta, scan)
+    assert list(df["status"]) == ["ok", "ok"]
+    assert list(df["sample_value"]) == [1, "a"]
+
+
+def test_build_field_status_empty_row_error():
+    meta = _meta([("f1", "integer")])
+    scan = {"data": [{"d": []}]}
+    df = build_field_status(meta, scan)
+    assert df.loc[0, "status"] == "error"
+
+
+def test_build_field_status_all_null():
+    meta = _meta([("f1", "integer")])
+    scan = {"data": [{"d": [None]}, {"d": [None]}]}
+    df = build_field_status(meta, scan)
+    assert df.loc[0, "status"] == "null"
+
+
+def test_build_field_status_no_rows():
+    meta = _meta([("f1", "integer")])
+    scan = {"data": []}
+    df = build_field_status(meta, scan)
+    assert df.loc[0, "status"] == "null"
+
+
+def test_build_field_status_mixed_empty():
+    meta = _meta([("f1", "integer")])
+    scan = {"data": [{"d": [None]}, {"d": [""]}]}
+    df = build_field_status(meta, scan)
+    assert df.loc[0, "status"] == "empty"


### PR DESCRIPTION
## Summary
- ensure TSV output doesn't include trailing newline
- extend `build_field_status` tests for more scenarios
- bump version to 1.0.33
- regenerate crypto API spec

## Testing
- `black .`
- `PYTHONPATH=$PWD pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684ce0393e74832ca0bfad250622543c