### PR TITLE
Update type inference docs and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.34
+- Version bump
 ## 1.0.33
 - Version bump
 ## 1.0.32

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Timeframe codes map to minutes unless otherwise noted:
 1W                          -> 1 week
 ```
 
+## Type Inference
+The :func:`infer_type` utility guesses the OpenAPI scalar type from example
+values. Strings equal to ``"true"`` or ``"false"`` in any case are treated as
+boolean; other strings default to ``string``.
+
 ## OpenAPI File Structure
 The generated YAML contains:
 - `openapi` and `info` – version and title.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.33"
+version = "1.0.34"
 requires-python = ">=3.10,<3.13"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.32
+  version: 1.0.33
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/src/utils/infer.py
+++ b/src/utils/infer.py
@@ -5,7 +5,11 @@ from datetime import datetime
 
 
 def infer_type(value: pd.Series | str | int | float | bool | None) -> str:
-    """Infer OpenAPI type from a sample value."""
+    """Infer OpenAPI type from a sample value.
+
+    Strings equal to ``"true"`` or ``"false"`` (case-insensitive) are
+    interpreted as boolean values.
+    """
     if isinstance(value, pd.Series):
         series = value.dropna()
         if series.empty:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -57,6 +57,11 @@ def test_infer_type_series_mixed():
     assert infer_type(series2) == "string"
 
 
+def test_infer_type_series_mixed_date_and_number():
+    series = pd.Series(["2023-01-01", 1])
+    assert infer_type(series) == "string"
+
+
 def test_infer_type_large_numbers():
     assert infer_type(10**12) == "integer"
     assert infer_type("1e10") == "number"

--- a/tests/test_type_mapping.py
+++ b/tests/test_type_mapping.py
@@ -1,28 +1,12 @@
-from src.utils.type_mapping import tv2ref
+from src.utils.type_mapping import tv2ref, TV_TYPE_TO_REF
 import pytest
 
 
-def test_tv2ref_known_types():
-    for t in [
-        "number",
-        "price",
-        "fundamental_price",
-        "percent",
-        "integer",
-        "float",
-    ]:
-        assert tv2ref(t) == "#/components/schemas/Num"
-
-    for t in ["bool", "boolean"]:
-        assert tv2ref(t) == "#/components/schemas/Bool"
-
-    for t in ["text", "map", "set", "interface", "string"]:
-        assert tv2ref(t) == "#/components/schemas/Str"
-
-    for t in ["time", "time-yyyymmdd"]:
-        assert tv2ref(t) == "#/components/schemas/Time"
+@pytest.mark.parametrize("tv_type,ref", TV_TYPE_TO_REF.items())
+def test_tv2ref_known_types(tv_type: str, ref: str) -> None:
+    assert tv2ref(tv_type) == ref
 
 
-def test_tv2ref_unknown_type():
+def test_tv2ref_unknown_type() -> None:
     with pytest.raises(KeyError):
         tv2ref("unknown")


### PR DESCRIPTION
## Summary
- document boolean string detection in README and `infer_type`
- add unexpected-series case for `infer_type`
- parametrize `tv2ref` tests over all known types
- bump version to 1.0.34

## Testing
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684ce17a6074832cbffce156db706837