### PR TITLE
Fix CI markets & TSV header in codex actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           # Allow failures and surface warnings for easier debugging
           set +e
           mkdir -p specs
-          for market in crypto forex stocks futures; do
+          for market in america bond cfd coin crypto forex futures stocks; do
             mkdir -p results/$market
             echo -e "field\ttv_type\tstatus\tsample_value\nclose\tinteger\tok\t1\nopen\tstring\tok\tabc" > results/$market/field_status.tsv
             echo '{ "market": "'$market'", "info": "Generated metadata" }' > results/$market/metainfo.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.35
+- Version bump
 ## 1.0.34
 - Version bump
 ## 1.0.33

--- a/codex_actions.py
+++ b/codex_actions.py
@@ -2,8 +2,12 @@ import subprocess
 import sys
 import json
 from pathlib import Path
-from src.constants import SCOPES
+
 import pandas as pd
+
+from src.constants import SCOPES
+
+STATUS_HEADER = "field\ttv_type\tstatus\tsample_value\n"
 
 
 def generate_openapi_spec() -> None:
@@ -20,7 +24,7 @@ def generate_openapi_spec() -> None:
         if not scan_file.exists():
             scan_file.write_text(json.dumps({"data": []}), encoding="utf-8")
         if not status_file.exists():
-            status_file.write_text("field\ttv_type\tstatus\tsample_value\n")
+            status_file.write_text(STATUS_HEADER)
         else:
             try:
                 df = pd.read_csv(status_file, sep="\t")
@@ -41,7 +45,7 @@ def generate_openapi_spec() -> None:
                     df = df[["field", "tv_type", "status", "sample_value"]]
                     df.to_csv(status_file, sep="\t", index=False)
             except Exception:
-                status_file.write_text("field\ttv_type\tstatus\tsample_value\n")
+                status_file.write_text(STATUS_HEADER)
 
     try:
         for market in SCOPES:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.34"
+version = "1.0.35"
 requires-python = ">=3.10,<3.13"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/america.yaml
+++ b/specs/america.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView America API
-  version: 1.0.31
+  version: 1.0.35
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -131,7 +131,8 @@ components:
       items: {}
     NumericFieldNoTimeframe:
       type: string
-      enum: []
+      enum:
+        - close
     NumericFieldWithTimeframe:
       type: string
       pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$

--- a/specs/bond.yaml
+++ b/specs/bond.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Bond API
-  version: 1.0.31
+  version: 1.0.35
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -131,7 +131,8 @@ components:
       items: {}
     NumericFieldNoTimeframe:
       type: string
-      enum: []
+      enum:
+        - close
     NumericFieldWithTimeframe:
       type: string
       pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$

--- a/specs/cfd.yaml
+++ b/specs/cfd.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Cfd API
-  version: 1.0.31
+  version: 1.0.35
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -131,7 +131,8 @@ components:
       items: {}
     NumericFieldNoTimeframe:
       type: string
-      enum: []
+      enum:
+        - close
     NumericFieldWithTimeframe:
       type: string
       pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$

--- a/specs/coin.yaml
+++ b/specs/coin.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Coin API
-  version: 1.0.31
+  version: 1.0.35
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -131,7 +131,8 @@ components:
       items: {}
     NumericFieldNoTimeframe:
       type: string
-      enum: []
+      enum:
+        - close
     NumericFieldWithTimeframe:
       type: string
       pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.34
+  version: 1.0.35
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/forex.yaml
+++ b/specs/forex.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Forex API
-  version: 1.0.31
+  version: 1.0.35
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -131,7 +131,8 @@ components:
       items: {}
     NumericFieldNoTimeframe:
       type: string
-      enum: []
+      enum:
+        - close
     NumericFieldWithTimeframe:
       type: string
       pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$

--- a/specs/futures.yaml
+++ b/specs/futures.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Futures API
-  version: 1.0.31
+  version: 1.0.35
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -131,7 +131,8 @@ components:
       items: {}
     NumericFieldNoTimeframe:
       type: string
-      enum: []
+      enum:
+        - close
     NumericFieldWithTimeframe:
       type: string
       pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$

--- a/specs/stocks.yaml
+++ b/specs/stocks.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Stocks API
-  version: 1.0.31
+  version: 1.0.35
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -131,7 +131,8 @@ components:
       items: {}
     NumericFieldNoTimeframe:
       type: string
-      enum: []
+      enum:
+        - close
     NumericFieldWithTimeframe:
       type: string
       pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$


### PR DESCRIPTION
## Summary
- ensure generated field_status.tsv files use new header
- validate all markets in CI
- bump version to 1.0.35
- regenerate specs

## Testing
- `flake8 codex_actions.py`
- `mypy codex_actions.py`
- `PYTHONPATH=$PWD pytest -q`
- `python - <<'PY'
from codex_actions import generate_openapi_spec, validate_spec

generate_openapi_spec()
validate_spec()
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684ce4dc6260832ca15da982e579b2a7