### PR TITLE
Improve collect() error handling

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -307,8 +307,23 @@ def collect(market: str, tickers: str, outdir: Path, offline: bool) -> None:
         df = build_field_status(meta_model, scan)
         tsv_text = df.to_csv(sep="\t", index=False)
         (market_dir / "field_status.tsv").write_text(tsv_text.rstrip("\n"))
+    except FileNotFoundError as exc:  # pragma: no cover - click handles output
+        with error_log.open("a") as fh:
+            fh.write(f"{type(exc).__name__}: {exc}\n")
+        raise click.ClickException("File not found")
+    except ValueError as exc:  # pragma: no cover - click handles output
+        with error_log.open("a") as fh:
+            fh.write(f"{type(exc).__name__}: {exc}\n")
+        raise click.ClickException("Invalid data")
+    except (
+        requests.exceptions.RequestException
+    ) as exc:  # pragma: no cover - click handles output
+        with error_log.open("a") as fh:
+            fh.write(f"{type(exc).__name__}: {exc}\n")
+        raise click.ClickException("Request failed")
     except Exception as exc:  # pragma: no cover - click handles output
-        error_log.write_text(str(exc))
+        with error_log.open("a") as fh:
+            fh.write(f"{type(exc).__name__}: {exc}\n")
         raise click.ClickException(str(exc))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -413,5 +413,6 @@ def test_collect_error(monkeypatch):
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ["collect", "--market", "crypto"])
         assert result.exit_code != 0
+        assert "File not found" in result.output
         log = Path("results/crypto/error.log").read_text()
-        assert log
+        assert "FileNotFoundError: boom" in log


### PR DESCRIPTION
## Summary
- catch FileNotFoundError, ValueError and RequestException separately in `collect`
- log exception type and message in `error.log`
- adjust test for new error message

## Testing
- `black src/cli.py tests/test_cli.py`
- `flake8`
- `mypy src`
- `pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684d4aa6b27c832c9f37912219635817