### PR TITLE
Fix CI spec generation path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             mkdir -p results/$market
             echo -e "field\ttv_type\tstatus\tsample_value\nclose\tinteger\tok\t1\nopen\tstring\tok\tabc" > results/$market/field_status.tsv
             echo '{ "market": "'$market'", "info": "Generated metadata" }' > results/$market/metainfo.json
-            tvgen generate --market $market --outdir specs/openapi_${market}.yaml
+            tvgen generate --market $market --outdir specs
             status=$?
             if [ $status -ne 0 ]; then
               echo "::warning file=tvgen::tvgen failed for $market (likely due to network issues)"
@@ -68,8 +68,8 @@ jobs:
           set -e
       - name: Validate all generated specs
         run: |
-          if ls specs/openapi_*.yaml 1> /dev/null 2>&1; then
-            for spec in specs/openapi_*.yaml; do
+          if ls specs/*.yaml 1> /dev/null 2>&1; then
+            for spec in specs/*.yaml; do
               openapi-spec-validator "$spec" || exit 1
             done
             echo "All specs validated successfully!"
@@ -95,8 +95,8 @@ jobs:
       - name: Summarize workflow
         run: |
           echo "Format, lint, type-check, and tests completed"
-          if ls specs/openapi_*.yaml 1> /dev/null 2>&1; then
-            echo "Specs generated: $(ls specs/openapi_*.yaml | wc -l)"
+          if ls specs/*.yaml 1> /dev/null 2>&1; then
+            echo "Specs generated: $(ls specs/*.yaml | wc -l)"
           else
             echo "No specs generated"
           fi


### PR DESCRIPTION
## Summary
- write specs directly under `specs/` in CI
- validate and summarize the new `<market>.yaml` paths

## Testing
- `black .`
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `python - <<'PY'
from codex_actions import generate_openapi_spec, validate_spec, run_tests

generate_openapi_spec()
validate_spec()
run_tests()
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684d4aac8024832cb1d2ebd0ac8d90be