### PR TITLE
Update enum explanation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ components:
   schemas:
     NumericFieldNoTimeframe:
       type: string
-      enum: [RSI, EMA20]
+      # enum is built from the available numeric fields such as [close, volume, ...]
     NumericFieldWithTimeframe:
       type: string
+      # pattern uses the timeframe codes parsed from this README
       pattern: "^[A-Z0-9_+\\[\\]]+\\|(1|5|15|30|60|120|240|1D|1W)$"
 ```
 


### PR DESCRIPTION
## Summary
- clarify that enum values come from numeric fields
- mention timeframe codes in example pattern

## Testing
- `black .`
- `PYTHONPATH=$PWD pytest -q`
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684d4ab44c30832caa29516a0cb4a10b