### PR TITLE
Add timeframe parser tests

### DIFF
--- a/tests/test_supported_timeframes.py
+++ b/tests/test_supported_timeframes.py
@@ -1,0 +1,22 @@
+from unittest import mock
+
+from src.generator.yaml_generator import _supported_timeframes
+
+
+def test_supported_timeframes_parsed() -> None:
+    text = (
+        "Timeframe codes map to minutes unless otherwise noted:\n"
+        "```\n"
+        "1, 5 -> minutes\n"
+        "1D -> 1 day\n"
+        "1W -> 1 week\n"
+        "```"
+    )
+    with mock.patch("pathlib.Path.read_text", return_value=text):
+        assert _supported_timeframes() == ["1", "5", "1D", "1W"]
+
+
+def test_supported_timeframes_default() -> None:
+    with mock.patch("pathlib.Path.read_text", return_value="no block"):
+        frames = _supported_timeframes()
+    assert frames == ["1", "5", "15", "30", "60", "120", "240", "1D", "1W"]


### PR DESCRIPTION
## Summary
- add regression tests for `_supported_timeframes`

## Testing
- `black .`
- `flake8 tests/test_supported_timeframes.py`
- `mypy src`
- `pytest -q`
- `python - <<'PY'
import os, codex_actions as ca
os.environ['PYTHONPATH']=os.getcwd()
ca.run_tests()
PY` (fails: tvgen command not found)

------
https://chatgpt.com/codex/tasks/task_e_684d4ab1ee14832c9365a3b82eeaf3ed