### PR TITLE
Fix /scan POST method

### DIFF
--- a/src/api/tradingview_api.py
+++ b/src/api/tradingview_api.py
@@ -91,8 +91,8 @@ class TradingViewAPI:
         return f"{self.base_url}/{scope}/{endpoint}"
 
     def scan(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """Send GET /{scope}/scan and return JSON validated by ``ScanResponse``."""
-        data = self._request(scope, "scan", "GET", payload)
+        """Send POST /{scope}/scan and return JSON validated by ``ScanResponse``."""
+        data = self._request(scope, "scan", "POST", payload)
         ScanResponse.parse_obj(data)
         return data
 

--- a/tests/test_additional_coverage.py
+++ b/tests/test_additional_coverage.py
@@ -44,7 +44,7 @@ def test_tradingview_request_error() -> None:
 
 def test_cli_scan_invalid_schema(tv_api_mock) -> None:
     runner = CliRunner()
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/crypto/scan",
         json={"foo": "bar"},
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,7 @@ def _create_metainfo(path: Path) -> None:
 
 def test_cli_scan(tv_api_mock) -> None:
     runner = CliRunner()
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/crypto/scan",
         json={"count": 0, "data": []},
     )
@@ -54,7 +54,7 @@ def test_cli_scan(tv_api_mock) -> None:
 
 def test_cli_scan_full_payload(tv_api_mock) -> None:
     runner = CliRunner()
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/crypto/scan",
         json={"count": 0, "data": []},
     )
@@ -84,7 +84,7 @@ def test_cli_scan_full_payload(tv_api_mock) -> None:
 
 def test_cli_recommend(tv_api_mock) -> None:
     runner = CliRunner()
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         json={"count": 1, "data": [{"s": "AAPL", "d": ["buy"]}]},
     )
@@ -95,7 +95,7 @@ def test_cli_recommend(tv_api_mock) -> None:
 
 def test_cli_price(tv_api_mock) -> None:
     runner = CliRunner()
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         json={"count": 1, "data": [{"s": "AAPL", "d": [1.0]}]},
     )
@@ -297,7 +297,7 @@ def test_cli_generate_missing_results(tmp_path: Path) -> None:
 
 def test_cli_scan_error(tv_api_mock) -> None:
     runner = CliRunner()
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/crypto/scan",
         status_code=500,
     )
@@ -312,7 +312,7 @@ def test_cli_scan_error(tv_api_mock) -> None:
 
 def test_cli_recommend_error(tv_api_mock) -> None:
     runner = CliRunner()
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         json={},
     )
@@ -324,7 +324,7 @@ def test_cli_recommend_error(tv_api_mock) -> None:
 
 def test_cli_price_error(tv_api_mock) -> None:
     runner = CliRunner()
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         json={},
     )

--- a/tests/test_stock_data.py
+++ b/tests/test_stock_data.py
@@ -3,7 +3,7 @@ from src.api.stock_data import fetch_recommendation, fetch_stock_value
 
 
 def test_fetch_recommendation(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         json={"count": 1, "data": [{"s": "AAPL", "d": ["strong_buy"]}]},
     )
@@ -11,7 +11,7 @@ def test_fetch_recommendation(tv_api_mock):
 
 
 def test_fetch_stock_value(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         json={"count": 1, "data": [{"s": "AAPL", "d": [150.0]}]},
     )
@@ -19,7 +19,7 @@ def test_fetch_stock_value(tv_api_mock):
 
 
 def test_fetch_stock_value_error(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         json={},
     )
@@ -29,7 +29,7 @@ def test_fetch_stock_value_error(tv_api_mock):
 
 
 def test_fetch_recommendation_error(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         json={},
     )
@@ -39,7 +39,7 @@ def test_fetch_recommendation_error(tv_api_mock):
 
 
 def test_fetch_stock_http_error(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         status_code=500,
     )
@@ -48,7 +48,7 @@ def test_fetch_stock_http_error(tv_api_mock):
 
 
 def test_fetch_recommend_http_error(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         status_code=404,
     )

--- a/tests/test_tradingview_api.py
+++ b/tests/test_tradingview_api.py
@@ -17,7 +17,7 @@ from src.api.tradingview_api import TradingViewAPI
     ],
 )
 def test_scan_and_metainfo(tv_api_mock, scope):
-    tv_api_mock.get(
+    tv_api_mock.post(
         f"https://scanner.tradingview.com/{scope}/scan",
         json={"count": 0, "data": []},
     )
@@ -50,7 +50,7 @@ def test_scan_and_metainfo(tv_api_mock, scope):
 
 
 def test_scan_error(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/crypto/scan",
         status_code=404,
     )
@@ -61,7 +61,7 @@ def test_scan_error(tv_api_mock):
 
 
 def test_scan_invalid_json(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/crypto/scan",
         text="not-json",
     )
@@ -71,7 +71,7 @@ def test_scan_invalid_json(tv_api_mock):
 
 
 def test_scan_invalid_schema(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/crypto/scan",
         json={"foo": "bar"},
     )


### PR DESCRIPTION
## Summary
- ensure TradingViewAPI.scan uses HTTP POST
- update CLI and API tests for POST
- update fetch_stock and recommendation tests

## Testing
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684d664aee34832cb858c73ab3db70b6