### PR TITLE
Add validation for search/history/summary

### DIFF
--- a/src/api/tradingview_api.py
+++ b/src/api/tradingview_api.py
@@ -7,7 +7,14 @@ from requests.adapters import HTTPAdapter, Retry
 import requests_cache
 
 from src.constants import SCOPES
-from src.models import MetaInfoResponse, ScanResponse
+from pydantic import ValidationError
+from src.models import (
+    MetaInfoResponse,
+    ScanResponse,
+    SearchResponse,
+    HistoryResponse,
+    SummaryResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -103,13 +110,28 @@ class TradingViewAPI:
         return data
 
     def search(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """POST /{scope}/search."""
-        return self._request(scope, "search", "POST", payload)
+        """POST /{scope}/search validated by ``SearchResponse``."""
+        data = self._request(scope, "search", "POST", payload)
+        try:
+            SearchResponse.parse_obj(data)
+        except ValidationError as exc:
+            raise ValueError("Invalid search response") from exc
+        return data
 
     def history(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """POST /{scope}/history."""
-        return self._request(scope, "history", "POST", payload)
+        """POST /{scope}/history validated by ``HistoryResponse``."""
+        data = self._request(scope, "history", "POST", payload)
+        try:
+            HistoryResponse.parse_obj(data)
+        except ValidationError as exc:
+            raise ValueError("Invalid history response") from exc
+        return data
 
     def summary(self, scope: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """POST /{scope}/summary."""
-        return self._request(scope, "summary", "POST", payload)
+        """POST /{scope}/summary validated by ``SummaryResponse``."""
+        data = self._request(scope, "summary", "POST", payload)
+        try:
+            SummaryResponse.parse_obj(data)
+        except ValidationError as exc:
+            raise ValueError("Invalid summary response") from exc
+        return data

--- a/src/models.py
+++ b/src/models.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, cast, Literal
+from typing import Any, cast, Literal, Dict
 
 from typing import Annotated
 
-from pydantic import BaseModel, Field, constr, confloat, AliasChoices
+from pydantic import BaseModel, Field, constr, confloat, AliasChoices, RootModel
 
 # Accepted TradingView field types
 FieldType = Literal[
@@ -88,4 +88,30 @@ class ScanResponse(TVBaseModel):
     )
 
 
-__all__ = ["TVField", "MetaInfoResponse", "ScanItem", "ScanResponse"]
+class GenericResponse(RootModel[Dict[str, Any]]):
+    """Generic mapping used for search/history/summary."""
+
+    root: Dict[str, Any]
+
+
+class SearchResponse(GenericResponse):
+    """Response model for ``/search`` endpoint."""
+
+
+class HistoryResponse(GenericResponse):
+    """Response model for ``/history`` endpoint."""
+
+
+class SummaryResponse(GenericResponse):
+    """Response model for ``/summary`` endpoint."""
+
+
+__all__ = [
+    "TVField",
+    "MetaInfoResponse",
+    "ScanItem",
+    "ScanResponse",
+    "SearchResponse",
+    "HistoryResponse",
+    "SummaryResponse",
+]

--- a/tests/test_tradingview_api.py
+++ b/tests/test_tradingview_api.py
@@ -104,6 +104,18 @@ def test_endpoint_invalid_json(tv_api_mock, endpoint):
         method("crypto", {})
 
 
+@pytest.mark.parametrize("endpoint", ["search", "history", "summary"])
+def test_endpoint_invalid_schema(tv_api_mock, endpoint):
+    tv_api_mock.post(
+        f"https://scanner.tradingview.com/crypto/{endpoint}",
+        json=[1, 2, 3],
+    )
+    api = TradingViewAPI()
+    method = getattr(api, endpoint)
+    with pytest.raises(ValueError):
+        method("crypto", {})
+
+
 def test_metainfo_error(tv_api_mock):
     tv_api_mock.post(
         "https://scanner.tradingview.com/crypto/metainfo",


### PR DESCRIPTION
## Summary
- add generic Pydantic models for search/history/summary
- validate responses in TradingViewAPI
- test validation of extra endpoints

## Testing
- `black . --quiet`
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684d678d3a78832c947fb74c33a95e1c