### PR TITLE
Document scan batch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ components:
       pattern: "^[A-Z0-9_+\\[\\]]+\\|(1|5|15|30|60|120|240|1D|1W)$"
 ```
 
+## Scan Request Batching
+TradingView limits `/scan` requests to 20 columns at a time. The
+`full_scan` helper in `data_fetcher.py` therefore splits the list of
+columns into chunks of this size (`MAX_COLUMNS_PER_SCAN`) and combines
+the partial responses.
+
 ## Import into GPT Builder
 1. Choose **Add Action** → **Upload YAML**.
 2. Select `specs/<market>.yaml`.

--- a/src/api/data_fetcher.py
+++ b/src/api/data_fetcher.py
@@ -9,6 +9,11 @@ from src.api.tradingview_api import TradingViewAPI
 
 _API = TradingViewAPI()
 
+# TradingView's ``/scan`` endpoint returns at most 20 columns per request.
+# To obtain data for more fields we issue multiple requests in parallel,
+# splitting the columns list into batches of this size.
+MAX_COLUMNS_PER_SCAN = 20
+
 
 def fetch_metainfo(
     scope: str, api_base: str = "https://scanner.tradingview.com"
@@ -125,7 +130,7 @@ def full_scan(
         tickers = choose_tickers(meta_json, limit=10)
 
     url = f"{api_base.rstrip('/')}/{scope}/scan"
-    batches = _chunks(columns, 20)
+    batches = _chunks(columns, MAX_COLUMNS_PER_SCAN)
 
     def _scan(cols: List[str]) -> Dict[str, Any]:
         payload = {

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -4,7 +4,13 @@ from pathlib import Path
 import pytest
 import requests
 
-from src.api.data_fetcher import fetch_metainfo, full_scan, save_json, choose_tickers
+from src.api.data_fetcher import (
+    fetch_metainfo,
+    full_scan,
+    save_json,
+    choose_tickers,
+    MAX_COLUMNS_PER_SCAN,
+)
 
 
 def test_fetch_metainfo(tv_api_mock):
@@ -43,15 +49,15 @@ def test_full_scan_single_batch(tv_api_mock):
 
 
 def test_full_scan_multi_batch(tv_api_mock):
-    first = {"count": 1, "data": [{"s": "AAA", "d": list(range(20))}]}
+    first = {"count": 1, "data": [{"s": "AAA", "d": list(range(MAX_COLUMNS_PER_SCAN))}]}
     second = {"count": 1, "data": [{"s": "AAA", "d": [99]}]}
     tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         [{"json": first}, {"json": second}],
     )
-    columns = [f"c{i}" for i in range(21)]
+    columns = [f"c{i}" for i in range(MAX_COLUMNS_PER_SCAN + 1)]
     result = full_scan("stocks", ["AAA"], columns)
-    assert result["data"][0]["d"] == list(range(20)) + [99]
+    assert result["data"][0]["d"] == list(range(MAX_COLUMNS_PER_SCAN)) + [99]
 
 
 def test_full_scan_batch_reorder(tv_api_mock):
@@ -73,7 +79,7 @@ def test_full_scan_batch_reorder(tv_api_mock):
         "https://scanner.tradingview.com/stocks/scan",
         [{"json": first}, {"json": second}],
     )
-    columns = [f"c{i}" for i in range(21)]
+    columns = [f"c{i}" for i in range(MAX_COLUMNS_PER_SCAN + 1)]
     result = full_scan("stocks", ["AAA", "BBB"], columns)
     assert [row["s"] for row in result["data"]] == ["AAA", "BBB"]
     assert result["data"][0]["d"] == [1, 2]


### PR DESCRIPTION
## Summary
- explain TradingView scan batch size limit
- refactor batch size magic number into `MAX_COLUMNS_PER_SCAN`
- adjust tests to use new constant

## Testing
- `black . --quiet`
- `flake8 .`
- `mypy src/`
- `PYTHONPATH=$PWD pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684d789fa1ec832c80ba48d538cfa98d