### PR TITLE
Fix payload column normalization suffix stripping

### DIFF
--- a/src/utils/payload.py
+++ b/src/utils/payload.py
@@ -16,7 +16,12 @@ def build_scan_payload(
     symbols_list = list(symbols)
 
     def _normalize(col: str) -> str:
-        return col[:-3] if col.endswith("|1D") else col
+        """Strip multi-day/week timeframe suffixes from the column name."""
+        if "|" in col:
+            base, suffix = col.rsplit("|", 1)
+            if suffix and suffix[-1] in {"D", "W"} and suffix[:-1].isdigit():
+                return base
+        return col
 
     columns_list = [_normalize(c) for c in columns]
 

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -68,3 +68,9 @@ def test_build_scan_payload_duplicate_columns():
 def test_build_scan_payload_strip_1d():
     payload = build_scan_payload(["A"], ["ADX+DI[1]|1D", "close"])
     assert payload["columns"] == ["ADX+DI[1]", "close"]
+
+
+@pytest.mark.parametrize("suffix", ["|3D", "|1W", "|10W"])
+def test_build_scan_payload_strip_other_suffixes(suffix):
+    payload = build_scan_payload(["A"], [f"close{suffix}"])
+    assert payload["columns"] == ["close"]


### PR DESCRIPTION
## Summary
- broaden `_normalize` in payload builder to drop any day/week suffix
- add tests covering various suffixes

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684d7bdb7da8832c81c8fd560edd48f3