### PR TITLE
Extend field type handling

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
-from typing import Any, cast, Literal, Dict
+from typing import Any, cast, Dict
 
-from typing import Annotated
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, constr, confloat, AliasChoices, RootModel
+from pydantic import (
+    BaseModel,
+    Field,
+    constr,
+    confloat,
+    AliasChoices,
+    RootModel,
+    field_validator,
+)
 
 # Accepted TradingView field types
-FieldType = Literal[
+KNOWN_FIELD_TYPES = [
     "number",
     "price",
     "fundamental_price",
@@ -24,7 +32,32 @@ FieldType = Literal[
     "time",
     "time-yyyymmdd",
     "array",
+    "duration",
+    "percentage",
 ]
+
+FieldTypeLiteral = Literal[
+    "number",
+    "price",
+    "fundamental_price",
+    "percent",
+    "integer",
+    "float",
+    "string",
+    "bool",
+    "boolean",
+    "text",
+    "map",
+    "set",
+    "interface",
+    "time",
+    "time-yyyymmdd",
+    "array",
+    "duration",
+    "percentage",
+]
+
+FieldType = Annotated[str, FieldTypeLiteral]
 
 
 class TVBaseModel(BaseModel):
@@ -46,6 +79,18 @@ class TVField(TVBaseModel):
         None
     )
     flags: list[str] | None = None
+
+    @field_validator("t", mode="before")
+    @classmethod
+    def _validate_type(cls, v: str) -> str:
+        if v not in KNOWN_FIELD_TYPES:
+            import warnings
+
+            warnings.warn(
+                f"Unknown TradingView field type '{v}', falling back to str",
+                RuntimeWarning,
+            )
+        return v
 
 
 class MetaInfoResponse(TVBaseModel):

--- a/src/utils/type_mapping.py
+++ b/src/utils/type_mapping.py
@@ -18,6 +18,8 @@ TV_TYPE_TO_REF: dict[str, str] = {
     "time": "#/components/schemas/Time",
     "time-yyyymmdd": "#/components/schemas/Time",
     "array": "#/components/schemas/Array",
+    "duration": "#/components/schemas/Num",
+    "percentage": "#/components/schemas/Num",
 }
 
 
@@ -26,7 +28,13 @@ def tv2ref(tv_type: str) -> str:
     try:
         return TV_TYPE_TO_REF[tv_type]
     except KeyError:
-        raise KeyError(tv_type) from None
+        import warnings
+
+        warnings.warn(
+            f"Unknown TradingView field type '{tv_type}', falling back to string",
+            RuntimeWarning,
+        )
+        return "#/components/schemas/Str"
 
 
 __all__ = ["TV_TYPE_TO_REF", "tv2ref"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -24,3 +24,9 @@ def test_scan_asset_validation() -> None:
 def test_scan_invalid() -> None:
     with pytest.raises(ValidationError):
         ScanResponse.parse_obj({"data": [{"d": []}]})
+
+
+def test_unknown_field_type_fallback() -> None:
+    data = {"fields": [{"name": "foo", "type": "mystery"}]}
+    model = MetaInfoResponse.parse_obj(data)
+    assert model.fields[0].t == "mystery"

--- a/tests/test_type_mapping.py
+++ b/tests/test_type_mapping.py
@@ -8,5 +8,10 @@ def test_tv2ref_known_types(tv_type: str, ref: str) -> None:
 
 
 def test_tv2ref_unknown_type() -> None:
-    with pytest.raises(KeyError):
-        tv2ref("unknown")
+    ref = tv2ref("unknown")
+    assert ref == "#/components/schemas/Str"
+
+
+def test_tv2ref_new_types() -> None:
+    assert tv2ref("duration") == "#/components/schemas/Num"
+    assert tv2ref("percentage") == "#/components/schemas/Num"

--- a/tests/test_yaml_generator_edges.py
+++ b/tests/test_yaml_generator_edges.py
@@ -11,8 +11,10 @@ def test_generate_yaml_unknown_field_type() -> None:
     object.__setattr__(field, "t", "unknown")
     meta = MetaInfoResponse(data=[field])
     tsv = pd.DataFrame()
-    with pytest.raises(KeyError):
-        generate_yaml("crypto", meta, tsv, None)
+    yaml_str = generate_yaml("crypto", meta, tsv, None)
+    data = yaml.safe_load(yaml_str)
+    props = data["components"]["schemas"]["CryptoFields"]["properties"]
+    assert props["foo"]["$ref"] == "#/components/schemas/Str"
 
 
 def test_generate_yaml_empty_and_none_scan() -> None:


### PR DESCRIPTION
## Summary
- support new TradingView field types
- warn and fall back to strings for unknown types
- adjust YAML generation and tests for fallback logic

## Testing
- `flake8 .`
- `mypy src`
- `pytest -q`
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684d7cfc5e5c832c84d51ecaf600a6f3