### PR TITLE
Update docs for CLI defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ After validating the spec, commit your changes with an updated `CHANGELOG.md`.
 ### Common CLI Flags
 
 - `--market` – TradingView market name
+- `--tickers` – comma-separated list (default `AUTO`)
+- `--indir`/`--outdir` – input/output directories (default `results`/`specs`)
+- `--workers` – parallel workers for `build` (default `1`)
 - `--filter2`, `--sort`, `--range` – optional JSON for `scan`
 
 ⚠️ **Note**: `tvgen generate` requires `results/<market>/field_status.tsv`. Create a minimal file if it doesn't exist.

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ docker run --rm ghcr.io/<owner>/tv-generator:latest \
 ```
 
 ## CLI Overview
-| Command      | Purpose                                   | Key Flags |
-|--------------|-------------------------------------------|-----------|
-| build        | collect+generate specs for all markets    | --indir • --outdir |
-| collect | download metainfo+scan, build TSV         | --market • --outdir • --tickers |
-| generate     | build OpenAPI spec                        | --market • --indir • --outdir • --max-size |
-| validate     | validate spec file                        | --spec |
-| preview      | show fields summary from spec             | --spec |
+| Command (alias) | Purpose                                       | Key Flags |
+|-----------------|-----------------------------------------------|-----------|
+| build / build-all | collect+generate specs for all markets        | `--indir` results, `--outdir` specs, `--workers` 1, `--offline` |
+| collect         | download metainfo+scan, build TSV             | `--market`, `--tickers` AUTO, `--outdir` results, `--offline` |
+| generate        | build OpenAPI spec                            | `--market`, `--indir` results, `--outdir` specs, `--max-size` 1048576 |
+| validate        | validate spec file                            | `--spec` |
+| preview         | show fields summary from spec                 | `--spec` |
 
 ### Short Examples
 ```bash

--- a/tests/test_yaml_generator_edges.py
+++ b/tests/test_yaml_generator_edges.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import yaml
-import pytest
 
 from src.generator.yaml_generator import generate_yaml
 from src.models import MetaInfoResponse, TVField


### PR DESCRIPTION
## Summary
- document default CLI flags for build/collect
- add details on common CLI flags
- remove unused import in tests

## Testing
- `black .`
- `flake8 .`
- `mypy src/`
- `PYTHONPATH=$PWD pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684e1b42f4dc832cbf09182ddc806b20