### PR TITLE
Update CI to validate OpenAPI spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,7 @@ jobs:
       - name: Test
         run: |
           PYTHONPATH=$PWD pytest -q
+      - name: Build OpenAPI spec
+        run: tvgen generate --market crypto --outdir specs
+      - name: Validate OpenAPI spec
+        run: openapi-spec-validator specs/*.yaml


### PR DESCRIPTION
## Summary
- extend workflow to generate and validate OpenAPI specs in the compatibility job

## Testing
- `black . --check`
- `flake8 .`
- `mypy --strict src/` *(fails: Returning Any from function declared to return "dict[str, Any]")*
- `PYTHONPATH=$PWD pytest -q` *(fails: 1 failed, 159 passed, 35 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684e329ad23c832cade6e3162ce94997