### PR TITLE
Use TradingViewAPI in fetch_metainfo

### DIFF
--- a/src/api/data_fetcher.py
+++ b/src/api/data_fetcher.py
@@ -18,17 +18,11 @@ MAX_COLUMNS_PER_SCAN = 20
 def fetch_metainfo(
     scope: str, api_base: str = "https://scanner.tradingview.com"
 ) -> Dict[str, Any]:
-    """Return metainfo for a given scope using GET request."""
-    url = f"{api_base.rstrip('/')}/{scope}/metainfo"
-    resp = _API.session.get(url, timeout=30)
-    resp.raise_for_status()
-    try:
-        data = resp.json()
-    except ValueError as exc:  # pragma: no cover - should not happen in tests
-        raise ValueError("Invalid JSON received from TradingView") from exc
-    if not isinstance(data, dict):
-        raise ValueError("Invalid JSON structure from TradingView")
-    MetaInfoResponse.parse_obj(data)
+    """Return metainfo for a given scope using the TradingViewAPI."""
+
+    # ``TradingViewAPI.metainfo`` sends the POST request and validates
+    # the response via ``MetaInfoResponse``.
+    data = _API.metainfo(scope, {"query": ""})
     return data
 
 

--- a/tests/test_additional_api_cases.py
+++ b/tests/test_additional_api_cases.py
@@ -22,7 +22,7 @@ def test_scan_request_exception(tv_api_mock):
 
 
 def test_fetch_metainfo_invalid_structure(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/metainfo",
         json=[1, 2, 3],
     )
@@ -31,7 +31,7 @@ def test_fetch_metainfo_invalid_structure(tv_api_mock):
 
 
 def test_full_scan_auto_tickers(tv_api_mock, monkeypatch):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/metainfo",
         json={"fields": [{"name": "symbol", "type": "string"}]},
     )

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -14,7 +14,7 @@ from src.api.data_fetcher import (
 
 
 def test_fetch_metainfo(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/metainfo",
         json={"fields": []},
     )
@@ -22,16 +22,16 @@ def test_fetch_metainfo(tv_api_mock):
 
 
 def test_fetch_metainfo_error(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/metainfo",
         status_code=500,
     )
-    with pytest.raises(requests.exceptions.HTTPError):
+    with pytest.raises(ValueError):
         fetch_metainfo("stocks")
 
 
 def test_fetch_metainfo_invalid_json(tv_api_mock):
-    tv_api_mock.get(
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/metainfo",
         text="not-json",
     )


### PR DESCRIPTION
## Summary
- delegate `fetch_metainfo` to `TradingViewAPI.metainfo`
- update tests for POST-based metainfo fetch

## Testing
- `black .`
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684e32cf8fdc832cba49fdbf93641595