### PR TITLE
Add environment variables section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.37
+- Version bump
 ## 1.0.36
 - Version bump
 ## 1.0.35

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ poetry run tvgen preview --spec specs/crypto.yaml
 ## Network Requirements
 The generation commands contact TradingView's public API. Ensure that `scanner.tradingview.com` is reachable from your environment. GitHub-hosted runners may block this traffic; use a self-hosted runner or run the generator locally if needed.
 
+## Environment Variables
+- `TV_BASE_URL`: базовый URL TradingView API (по умолчанию scanner.tradingview.com)
+- `TV_CACHE`: если установлено, включает `requests-cache` для ускорения повторных запросов
+
 ### Docker
 ```bash
 docker run --rm ghcr.io/<owner>/tv-generator:latest \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.36"
+version = "1.0.37"
 requires-python = ">=3.10"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 


### PR DESCRIPTION
## Summary
- document TV_BASE_URL and TV_CACHE in README
- bump version to 1.0.37

## Testing
- `black .`
- `flake8 .`
- `mypy src`
- `pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684e32e531b0832c89aff65cfbdbdeef