### PR TITLE
Add fallback for tickers when scan field missing

### DIFF
--- a/src/api/data_fetcher.py
+++ b/src/api/data_fetcher.py
@@ -67,6 +67,12 @@ def choose_tickers(
             symbol_idx = idx
             break
 
+    body = meta_dict.get("body") or meta_dict.get("data", {})
+    if symbol_idx is None and isinstance(body, dict):
+        symbols_list = body.get("symbols") or []
+        if symbols_list:
+            return [s if isinstance(s, str) else s[0] for s in symbols_list][:limit]
+
     tickers: list[str] = []
 
     scan = meta_dict.get("scan")


### PR DESCRIPTION
## Summary
- return tickers from `meta['body']['symbols']` when scan column for symbols is missing

## Testing
- `black . --quiet`
- `flake8 .`
- `mypy src/`
- `PYTHONPATH=$PWD pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684e32f85d20832c816a14417436aa8d