### PR TITLE
Improve YAML generation API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,19 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install black flake8 mypy pytest pytest-cov openapi-spec-validator requests_mock \
-            types-requests types-PyYAML types-toml -r requirements.txt
-          pip install -e .
-      - name: Format
-        run: black --check .
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install black flake8 mypy pytest pytest-cov openapi-spec-validator requests_mock \
+              types-requests types-PyYAML types-toml -r requirements.txt
+            pip install -e .
+        - name: Validate repository specs
+          run: |
+            if ls specs/*.yaml 1> /dev/null 2>&1; then
+              openapi-spec-validator specs/*.yaml
+            fi
+        - name: Format
+          run: black --check .
       - name: Lint
         run: flake8 .
       - name: Type check

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.36
+  version: 1.0.37
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/src/cli.py
+++ b/src/cli.py
@@ -445,7 +445,7 @@ def generate(market: str, indir: Path, outdir: Path, max_size: int) -> None:
                 tv_fields.append(TVField.model_validate(data))
     meta = MetaInfoResponse(data=tv_fields)
 
-    yaml_str = generate_yaml(market, meta, tsv, scan_data, max_size=max_size)
+    yaml_str = generate_yaml(market, meta, scan_data, max_size=max_size)
 
     outdir.mkdir(parents=True, exist_ok=True)
     out_file = outdir / f"{market}.yaml"

--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -292,7 +292,6 @@ def build_paths_section(scope: str, cap: str) -> Dict[str, Any]:
 def generate_yaml(
     scope: str,
     meta: MetaInfoResponse,
-    _tsv: "pd.DataFrame",
     scan: dict[str, Any] | None = None,
     server_url: str = "https://scanner.tradingview.com",
     max_size: int = 1_048_576,

--- a/tests/test_additional_api_cases.py
+++ b/tests/test_additional_api_cases.py
@@ -64,7 +64,6 @@ def test_build_field_status_with_columns():
 
 def test_generate_yaml_server_url():
     meta = MetaInfoResponse(data=[TVField(name="close", type="integer")])
-    tsv = pd.DataFrame()
-    yaml_str = generate_yaml("crypto", meta, tsv, None, server_url="http://example.com")
+    yaml_str = generate_yaml("crypto", meta, None, server_url="http://example.com")
     data = yaml.safe_load(yaml_str)
     assert data["servers"][0]["url"] == "http://example.com"

--- a/tests/test_field_coverage.py
+++ b/tests/test_field_coverage.py
@@ -19,8 +19,7 @@ def _load_meta() -> MetaInfoResponse:
 
 def test_field_coverage() -> None:
     meta = _load_meta()
-    tsv = pd.DataFrame(columns=["field", "tv_type", "status", "sample_value"])
-    yaml_str = generate_yaml("coin", meta, tsv, None)
+    yaml_str = generate_yaml("coin", meta, None)
     spec = yaml.safe_load(yaml_str)
     props = spec["components"]["schemas"]["CoinFields"]["properties"]
     yaml_fields = set(props.keys())

--- a/tests/test_yaml_generator.py
+++ b/tests/test_yaml_generator.py
@@ -21,9 +21,8 @@ def _sample_meta() -> MetaInfoResponse:
 
 def test_generate_yaml() -> None:
     meta = _sample_meta()
-    tsv = pd.DataFrame(columns=["field", "tv_type", "status", "sample_value"])
     with mock.patch("toml.load", return_value={"project": {"version": "1.2.3"}}):
-        yaml_str = generate_yaml("crypto", meta, tsv, None)
+        yaml_str = generate_yaml("crypto", meta, None)
     data = yaml.safe_load(yaml_str)
     assert data["info"]["version"] == "1.2.3"
     assert "/crypto/scan" in data["paths"]
@@ -43,10 +42,9 @@ def test_generate_yaml() -> None:
 
 def test_generate_yaml_size_limit() -> None:
     meta = _sample_meta()
-    tsv = pd.DataFrame()
     with mock.patch("toml.load", return_value={"project": {"version": "1.0"}}):
         with pytest.raises(RuntimeError):
-            generate_yaml("crypto", meta, tsv, None, max_size=10)
+            generate_yaml("crypto", meta, None, max_size=10)
 
 
 def test_numeric_field_components() -> None:
@@ -55,8 +53,7 @@ def test_numeric_field_components() -> None:
         TVField(name="ADX+DI[1]|60", type="number"),
     ]
     meta = MetaInfoResponse(data=fields)
-    tsv = pd.DataFrame()
-    yaml_str = generate_yaml("crypto", meta, tsv, None)
+    yaml_str = generate_yaml("crypto", meta, None)
     data = yaml.safe_load(yaml_str)
     schemas = data["components"]["schemas"]
     assert schemas["NumericFieldNoTimeframe"]["enum"] == []
@@ -70,8 +67,7 @@ def test_symbol_field_ignored() -> None:
             TVField(name="close", type="integer"),
         ]
     )
-    tsv = pd.DataFrame()
-    yaml_str = generate_yaml("crypto", meta, tsv, None)
+    yaml_str = generate_yaml("crypto", meta, None)
     data = yaml.safe_load(yaml_str)
     props = data["components"]["schemas"]["CryptoFields"]["properties"]
     assert "symbol" not in props
@@ -101,8 +97,7 @@ def test_build_paths_section() -> None:
 def test_fields_split_into_parts() -> None:
     fields = [TVField(name=f"f{i}", type="number") for i in range(130)]
     meta = MetaInfoResponse(data=fields)
-    tsv = pd.DataFrame()
-    yaml_str = generate_yaml("crypto", meta, tsv, None)
+    yaml_str = generate_yaml("crypto", meta, None)
     data = yaml.safe_load(yaml_str)
     schemas = data["components"]["schemas"]
     assert "CryptoFieldsPart01" in schemas

--- a/tests/test_yaml_generator_edges.py
+++ b/tests/test_yaml_generator_edges.py
@@ -9,8 +9,7 @@ def test_generate_yaml_unknown_field_type() -> None:
     field = TVField(name="foo", type="integer")
     object.__setattr__(field, "t", "unknown")
     meta = MetaInfoResponse(data=[field])
-    tsv = pd.DataFrame()
-    yaml_str = generate_yaml("crypto", meta, tsv, None)
+    yaml_str = generate_yaml("crypto", meta, None)
     data = yaml.safe_load(yaml_str)
     props = data["components"]["schemas"]["CryptoFields"]["properties"]
     assert props["foo"]["$ref"] == "#/components/schemas/Str"
@@ -18,9 +17,8 @@ def test_generate_yaml_unknown_field_type() -> None:
 
 def test_generate_yaml_empty_and_none_scan() -> None:
     meta = MetaInfoResponse(data=[TVField(name="close", type="integer")])
-    tsv = pd.DataFrame()
     for scan in [None, {"data": []}]:
-        yaml_str = generate_yaml("crypto", meta, tsv, scan)
+        yaml_str = generate_yaml("crypto", meta, scan)
         data = yaml.safe_load(yaml_str)
         assert "CryptoFields" in data["components"]["schemas"]
 
@@ -28,8 +26,7 @@ def test_generate_yaml_empty_and_none_scan() -> None:
 def test_numeric_field_with_custom_timeframe() -> None:
     field = TVField(name="ADX+DI[1]|90", type="number")
     meta = MetaInfoResponse(data=[field])
-    tsv = pd.DataFrame()
-    yaml_str = generate_yaml("crypto", meta, tsv, None)
+    yaml_str = generate_yaml("crypto", meta, None)
     data = yaml.safe_load(yaml_str)
     props = data["components"]["schemas"]["CryptoFields"]["properties"]
     assert "90-minute" in props["ADX+DI[1]|90"]["description"]

--- a/tests/test_yaml_generator_large.py
+++ b/tests/test_yaml_generator_large.py
@@ -10,8 +10,7 @@ def test_generate_yaml_large() -> None:
     for i in range(120):
         fields.append(TVField(name=f"f{i}", type=types[i % len(types)]))
     meta = MetaInfoResponse(data=fields)
-    tsv = pd.DataFrame(columns=["field", "tv_type", "status", "sample_value"])
-    yaml_str = generate_yaml("coin", meta, tsv, None)
+    yaml_str = generate_yaml("coin", meta, None)
     data = yaml.safe_load(yaml_str)
 
     schemas = data["components"]["schemas"]


### PR DESCRIPTION
## Summary
- drop unused `_tsv` argument from `generate_yaml`
- adjust CLI and tests to new `generate_yaml` signature
- validate repo specs in CI
- regenerate crypto spec

## Testing
- `black src tests`
- `flake8 src tests`
- `mypy src`
- `PYTHONPATH=$PWD pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`
- `openapi-spec-validator specs/*.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684e35154ac4832cbeced52e6a6cabcc