### PR TITLE
Fix fetch_metainfo signature and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.38
+- Document additional environment variables and remove unused parameter
 ## 1.0.37
 - Version bump
 ## 1.0.36

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The generation commands contact TradingView's public API. Ensure that `scanner.t
 ## Environment Variables
 - `TV_BASE_URL`: базовый URL TradingView API (по умолчанию scanner.tradingview.com)
 - `TV_CACHE`: если установлено, включает `requests-cache` для ускорения повторных запросов
+- `TV_CACHE_EXPIRE`: время жизни кэша в секундах (по умолчанию 86400)
+- `TV_TIMEOUT`: тайм‑аут HTTP-запросов в секундах (по умолчанию 10)
 
 ### Docker
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.37"
+version = "1.0.38"
 requires-python = ">=3.10"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/america.yaml
+++ b/specs/america.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView America API
-  version: 1.0.36
+  version: 1.0.38
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/bond.yaml
+++ b/specs/bond.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Bond API
-  version: 1.0.36
+  version: 1.0.38
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/cfd.yaml
+++ b/specs/cfd.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Cfd API
-  version: 1.0.36
+  version: 1.0.38
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/coin.yaml
+++ b/specs/coin.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Coin API
-  version: 1.0.36
+  version: 1.0.38
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.36
+  version: 1.0.38
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/forex.yaml
+++ b/specs/forex.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Forex API
-  version: 1.0.36
+  version: 1.0.38
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/futures.yaml
+++ b/specs/futures.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Futures API
-  version: 1.0.36
+  version: 1.0.38
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/stocks.yaml
+++ b/specs/stocks.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Stocks API
-  version: 1.0.36
+  version: 1.0.38
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/src/api/data_fetcher.py
+++ b/src/api/data_fetcher.py
@@ -15,9 +15,7 @@ _API = TradingViewAPI()
 MAX_COLUMNS_PER_SCAN = 20
 
 
-def fetch_metainfo(
-    scope: str, api_base: str = "https://scanner.tradingview.com"
-) -> Dict[str, Any]:
+def fetch_metainfo(scope: str) -> Dict[str, Any]:
     """Return metainfo for a given scope using the TradingViewAPI."""
 
     # ``TradingViewAPI.metainfo`` sends the POST request and validates
@@ -126,7 +124,7 @@ def full_scan(
 ) -> Dict[str, Any]:
     """Perform a scan request splitting columns into batches."""
     if tickers == ["AUTO"]:
-        meta_json = fetch_metainfo(scope, api_base)
+        meta_json = fetch_metainfo(scope)
         tickers = choose_tickers(meta_json, limit=10)
 
     url = f"{api_base.rstrip('/')}/{scope}/scan"


### PR DESCRIPTION
## Summary
- drop unused parameter from `fetch_metainfo`
- update README with `TV_CACHE_EXPIRE` and `TV_TIMEOUT`
- bump version to `1.0.38`
- regenerate OpenAPI specs

## Testing
- `pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`
- `openapi-spec-validator specs/*.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684e35154ac4832cbeced52e6a6cabcc