### PR TITLE
Handle missing pyproject when generating YAML

### DIFF
--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -300,7 +300,15 @@ def generate_yaml(
 
     cap = scope.capitalize()
     root = Path(__file__).resolve().parents[2]
-    version = toml.load(root / "pyproject.toml")["project"]["version"]
+    try:
+        version = toml.load(root / "pyproject.toml")["project"]["version"]
+    except FileNotFoundError:  # pragma: no cover - fallback for installed package
+        try:
+            from importlib.metadata import PackageNotFoundError, version as pkg_version
+
+            version = pkg_version("tv-generator")
+        except PackageNotFoundError:  # pragma: no cover - dev environment
+            version = "0.0.0"
 
     fields, no_tf_enum = collect_field_schemas(meta, scan)
     components = build_components_schemas(cap, fields, no_tf_enum)


### PR DESCRIPTION
## Summary
- fall back to package metadata if pyproject.toml not found when building OpenAPI specs

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `tvgen generate --market crypto --outdir specs`
- `openapi-spec-validator specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684e3801b050832c88dc5ece061c8aec