### PR TITLE
Handle alternate field keys in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.38
+- Support alternate field keys in metainfo responses
 ## 1.0.37
 - Version bump
 ## 1.0.36

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.37"
+version = "1.0.38"
 requires-python = ">=3.10"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.37
+  version: 1.0.38
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/src/models.py
+++ b/src/models.py
@@ -72,8 +72,14 @@ class TVBaseModel(BaseModel):
 class TVField(TVBaseModel):
     """TradingView field description."""
 
-    n: Annotated[str, constr(strip_whitespace=True, min_length=1)] = Field(alias="name")
-    t: FieldType = Field(alias="type")
+    n: Annotated[str, constr(strip_whitespace=True, min_length=1)] = Field(
+        serialization_alias="name",
+        validation_alias=AliasChoices("name", "id", "n"),
+    )
+    t: FieldType = Field(
+        serialization_alias="type",
+        validation_alias=AliasChoices("type", "t"),
+    )
     interval: Annotated[float, confloat(gt=0)] | None = None
     description: Annotated[str, constr(strip_whitespace=True, min_length=1)] | None = (
         None


### PR DESCRIPTION
## Summary
- accept short 'n'/'t' field keys when parsing TradingView metainfo
- bump version to 1.0.38
- update generated spec

## Testing
- `black .`
- `flake8 .` *(fails: F401, F841)*
- `mypy src/`
- `PYTHONPATH=$PWD pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684e3a774f68832c8935380b22a5b7ea