### PR TITLE
Fix global API usage

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -460,7 +460,13 @@ def generate(market: str, indir: Path, outdir: Path, max_size: int) -> None:
                 tv_fields.append(TVField.model_validate(data))
     meta = MetaInfoResponse(data=tv_fields)
 
-    yaml_str = generate_yaml(market, meta, scan_data, max_size=max_size)
+    yaml_str = generate_yaml(
+        market,
+        meta,
+        scan_data,
+        max_size=max_size,
+        api=TradingViewAPI(),
+    )
 
     outdir.mkdir(parents=True, exist_ok=True)
     out_file = outdir / f"{market}.yaml"

--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -9,6 +9,7 @@ import yaml
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     import pandas as pd
+    from src.api.tradingview_api import TradingViewAPI
 
 from src.models import MetaInfoResponse
 from src.utils import tv2ref
@@ -295,8 +296,13 @@ def generate_yaml(
     scan: dict[str, Any] | None = None,
     server_url: str = "https://scanner.tradingview.com",
     max_size: int = 1_048_576,
+    *,
+    api: "TradingViewAPI" | None = None,
 ) -> str:
     """Return OpenAPI YAML specification for a scope."""
+
+    if api is not None:
+        server_url = str(api.base_url)
 
     cap = scope.capitalize()
     root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary
- remove global TradingViewAPI instance
- instantiate API per call and when generating spec in threads
- allow passing API into YAML generator

## Testing
- `black src/api/data_fetcher.py src/cli.py src/generator/yaml_generator.py`
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684e8e768f24832c8df444f610910905