### PR TITLE
Fix API instantiation for thread safety

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -460,7 +460,8 @@ def generate(market: str, indir: Path, outdir: Path, max_size: int) -> None:
                 tv_fields.append(TVField.model_validate(data))
     meta = MetaInfoResponse(data=tv_fields)
 
-    yaml_str = generate_yaml(market, meta, scan_data, max_size=max_size)
+    api = TradingViewAPI()
+    yaml_str = generate_yaml(market, meta, scan_data, max_size=max_size, api=api)
 
     outdir.mkdir(parents=True, exist_ok=True)
     out_file = outdir / f"{market}.yaml"

--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
     import pandas as pd
 
 from src.models import MetaInfoResponse
+from src.api.tradingview_api import TradingViewAPI
 from src.utils import tv2ref
 
 
@@ -295,6 +296,7 @@ def generate_yaml(
     scan: dict[str, Any] | None = None,
     server_url: str = "https://scanner.tradingview.com",
     max_size: int = 1_048_576,
+    api: TradingViewAPI | None = None,
 ) -> str:
     """Return OpenAPI YAML specification for a scope."""
 


### PR DESCRIPTION
## Summary
- remove global API instance from data_fetcher
- build API per call in data_fetcher
- create API for YAML generation
- support optional API parameter in generator

## Testing
- `black .`
- `flake8 .`
- `mypy src`
- `pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684e8e768f24832c8df444f610910905