### PR TITLE
Handle missing pyproject version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.39
+- Version bump
 ## 1.0.38
 - Support alternate field keys in metainfo responses
 ## 1.0.37

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.38"
+version = "1.0.39"
 requires-python = ">=3.10"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -15,6 +15,21 @@ from src.api.tradingview_api import TradingViewAPI
 from src.utils import tv2ref
 
 
+def get_project_version() -> str:
+    """Return project version from pyproject.toml."""
+
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    try:
+        data = toml.load(pyproject)
+    except FileNotFoundError:
+        raise RuntimeError("Version not found in pyproject.toml")
+
+    version = data.get("project", {}).get("version")
+    if not version:
+        raise RuntimeError("Version not found in pyproject.toml")
+    return str(version)
+
+
 def _supported_timeframes() -> list[str]:
     """Return list of supported timeframe codes parsed from README."""
     root = Path(__file__).resolve().parents[2]
@@ -301,10 +316,9 @@ def generate_yaml(
     """Return OpenAPI YAML specification for a scope."""
 
     cap = scope.capitalize()
-    root = Path(__file__).resolve().parents[2]
     try:
-        version = toml.load(root / "pyproject.toml")["project"]["version"]
-    except FileNotFoundError:  # pragma: no cover - fallback for installed package
+        version = get_project_version()
+    except RuntimeError:  # pragma: no cover - fallback for installed package
         try:
             from importlib.metadata import PackageNotFoundError, version as pkg_version
 


### PR DESCRIPTION
## Summary
- add get_project_version helper for reading version safely
- fallback to package metadata when pyproject version can't be read
- bump version to 1.0.39

## Testing
- `pip install -r requirements.txt`
- `black . --check`
- `flake8 .`
- `mypy src/`
- `PYTHONPATH=$PWD pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684eb6069d80832c9573a432eb3e8e6d