### PR TITLE
Improve CLI error messages

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,7 @@ def test_cli_scan_invalid_filter(tv_api_mock) -> None:
         ],
     )
     assert result.exit_code != 0
-    assert "Invalid JSON in option: --filter" in result.output
+    assert "Invalid JSON in --filter" in result.output
 
 
 def test_cli_scan_full_payload(tv_api_mock) -> None:
@@ -119,7 +119,7 @@ def test_cli_scan_invalid_sort(tv_api_mock) -> None:
         ],
     )
     assert result.exit_code != 0
-    assert "Invalid JSON in option: --sort" in result.output
+    assert "Invalid JSON in --sort" in result.output
 
 
 def test_cli_scan_invalid_filter2(tv_api_mock) -> None:
@@ -139,7 +139,7 @@ def test_cli_scan_invalid_filter2(tv_api_mock) -> None:
         ],
     )
     assert result.exit_code != 0
-    assert "Invalid JSON in option: --filter2" in result.output
+    assert "Invalid JSON in --filter2" in result.output
 
 
 def test_cli_scan_invalid_range(tv_api_mock) -> None:
@@ -159,7 +159,7 @@ def test_cli_scan_invalid_range(tv_api_mock) -> None:
         ],
     )
     assert result.exit_code != 0
-    assert "Invalid JSON in option: --range" in result.output
+    assert "Invalid JSON in --range" in result.output
 
 
 def test_cli_recommend(tv_api_mock) -> None:
@@ -266,7 +266,7 @@ def test_cli_search_invalid_payload() -> None:
     )
     assert result.exit_code != 0
     assert result.exception is not None
-    assert "Invalid JSON in option: --payload" in result.output
+    assert "Invalid JSON in --payload" in result.output
 
 
 def test_cli_history_invalid_payload() -> None:
@@ -277,7 +277,7 @@ def test_cli_history_invalid_payload() -> None:
     )
     assert result.exit_code != 0
     assert result.exception is not None
-    assert "Invalid JSON in option: --payload" in result.output
+    assert "Invalid JSON in --payload" in result.output
 
 
 def test_cli_summary_invalid_payload() -> None:
@@ -288,7 +288,7 @@ def test_cli_summary_invalid_payload() -> None:
     )
     assert result.exit_code != 0
     assert result.exception is not None
-    assert "Invalid JSON in option: --payload" in result.output
+    assert "Invalid JSON in --payload" in result.output
 
 
 def test_scan_cli_missing_scope():
@@ -389,7 +389,7 @@ def test_cli_scan_error(tv_api_mock) -> None:
     )
     assert result.exit_code != 0
     assert result.exception is not None
-    assert "500" in result.output
+    assert "TradingView request failed" in result.output
 
 
 def test_cli_recommend_error(tv_api_mock) -> None:
@@ -425,7 +425,7 @@ def test_cli_metainfo_error(tv_api_mock) -> None:
     result = runner.invoke(cli, ["metainfo", "--query", "t", "--market", "crypto"])
     assert result.exit_code != 0
     assert result.exception is not None
-    assert "500" in result.output
+    assert "TradingView request failed" in result.output
 
 
 def test_cli_validate_missing_file() -> None:


### PR DESCRIPTION
## Notes
- Follow AGENTS instructions
- Improved _with_error_handling to catch RequestException/ValidationError/KeyError and convert TradingView HTTP errors to ClickException
- Modified _parse_json_option to remove "option:" wording
- Added friendly error message for missing tickers in collect
- Routed metainfo command through _with_error_handling
- Updated tests for new messages

## Summary
- Map HTTP and request errors to `TradingView request failed`
- Simplify JSON parse errors (`Invalid JSON in --<opt>`)
- Show `No symbols found in metainfo` when tickers missing
- Adjust tests to match new output

## Testing
- `black . --check`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eba7f285c832cbd620ef8b63c18fa