### PR TITLE
Refactor build generation workflow

### DIFF
--- a/src/generator/__init__.py
+++ b/src/generator/__init__.py
@@ -1,5 +1,5 @@
 """OpenAPI specification generation tools."""
 
-from .yaml_generator import generate_yaml
+from .yaml_generator import generate_yaml, generate_for_market
 
-__all__ = ["generate_yaml"]
+__all__ = ["generate_yaml", "generate_for_market"]

--- a/tests/test_additional_api_cases.py
+++ b/tests/test_additional_api_cases.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pytest
 import requests
 import yaml

--- a/tests/test_field_coverage.py
+++ b/tests/test_field_coverage.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import json
 import yaml
-import pandas as pd
 from src.generator.yaml_generator import generate_yaml
 from src.models import MetaInfoResponse, TVField
 

--- a/tests/test_yaml_generator.py
+++ b/tests/test_yaml_generator.py
@@ -1,5 +1,4 @@
 import yaml
-import pandas as pd
 import pytest
 from unittest import mock
 from src.generator.yaml_generator import (

--- a/tests/test_yaml_generator_edges.py
+++ b/tests/test_yaml_generator_edges.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import yaml
 
 from src.generator.yaml_generator import generate_yaml

--- a/tests/test_yaml_generator_large.py
+++ b/tests/test_yaml_generator_large.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import yaml
 from src.generator.yaml_generator import generate_yaml
 from src.models import MetaInfoResponse, TVField


### PR DESCRIPTION
## Summary
- share single function to generate specs for a market
- use new helper in CLI `generate` and `build`
- export helper from `generator` package
- cleanup unused pandas imports in tests

## Testing
- `black . --check`
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684ecbea589c832ca9778753f4e64347