### PR TITLE
Add YAML splitting test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.39
+- Version bump
 ## 1.0.38
 - Support alternate field keys in metainfo responses
 ## 1.0.37

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.38"
+version = "1.0.39"
 requires-python = ">=3.10"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/src/api/data_fetcher.py
+++ b/src/api/data_fetcher.py
@@ -148,7 +148,8 @@ def full_scan(
 
     result_map: dict[str, list[Any]] = {sym: [] for sym in tickers}
     with ThreadPoolExecutor(max_workers=min(8, len(batches))) as executor:
-        responses = list(executor.map(_scan, batches))
+        futures = [executor.submit(_scan, cols) for cols in batches]
+        responses = [future.result() for future in futures]
 
     for data in responses:
         rows = data.get("data", []) if isinstance(data, dict) else []

--- a/tests/test_yaml_generator.py
+++ b/tests/test_yaml_generator.py
@@ -104,3 +104,17 @@ def test_fields_split_into_parts() -> None:
     parts = schemas["CryptoFields"]["allOf"]
     assert {"$ref": "#/components/schemas/CryptoFieldsPart01"} in parts
     assert {"$ref": "#/components/schemas/CryptoFieldsPart02"} in parts
+
+
+def test_fields_split_into_two_parts_at_hundred() -> None:
+    fields = [TVField(name=f"field{i}", type="number") for i in range(100)]
+    meta = MetaInfoResponse(data=fields)
+    yaml_str = generate_yaml("crypto", meta, None)
+    data = yaml.safe_load(yaml_str)
+    schemas = data["components"]["schemas"]
+    assert "CryptoFieldsPart01" in schemas
+    assert "CryptoFieldsPart02" in schemas
+    parts = schemas["CryptoFields"]["allOf"]
+    assert len(parts) == 2
+    assert {"$ref": "#/components/schemas/CryptoFieldsPart01"} in parts
+    assert {"$ref": "#/components/schemas/CryptoFieldsPart02"} in parts


### PR DESCRIPTION
## Summary
- ensure `full_scan` keeps batch order
- test YAML generator when fields >64 split into two parts
- bump version to 1.0.39

## Testing
- `pytest -q`
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684ecfe4ec18832cb74fa355f9095e67