### PR TITLE
Add test for metainfo schema failure

### DIFF
--- a/tests/test_metainfo_validation.py
+++ b/tests/test_metainfo_validation.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+from click.testing import CliRunner
+from pydantic import ValidationError
+
+from src.cli import cli
+from src.api.tradingview_api import TradingViewAPI
+
+
+def test_metainfo_invalid_schema(monkeypatch):
+    runner = CliRunner()
+
+    def fake_request(self, scope: str, endpoint: str, method: str, payload: dict):
+        data = {"foo": "bar"}
+        path = Path("results") / scope / "metainfo.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data))
+        return data
+
+    monkeypatch.setattr(TradingViewAPI, "_request", fake_request)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli, ["metainfo", "--query", "crypto", "--market", "crypto"]
+        )
+        assert result.exit_code != 0
+        assert "1 validation error for MetaInfoResponse" in result.output
+        saved = Path("results/crypto/metainfo.json")
+        assert saved.exists()
+        assert json.loads(saved.read_text()) == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- check `tvgen metainfo` validation error handling

## Testing
- `black .`
- `flake8 .`
- `mypy src/ tests/test_metainfo_validation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed1b584d8832ca6aa8f649580e1da