### PR TITLE
Implement GET fallback for scan method

### DIFF
--- a/src/api/stock_data.py
+++ b/src/api/stock_data.py
@@ -22,7 +22,7 @@ def _fetch_field(symbol: str, scope: str, column: str, error_msg: str) -> Any:
         logger.error("Invalid scan response for %s in %s: %s", symbol, scope, exc)
         raise ValueError(f"{error_msg} for {symbol} in market {scope}") from exc
     try:
-        return data["data"][0]["d"][0]
+        return data.data[0].d[0]
     except (KeyError, IndexError) as exc:
         logger.error("%s for %s in %s: %s", error_msg, symbol, scope, exc)
         raise ValueError(f"{error_msg} for {symbol} in market {scope}") from exc

--- a/src/cli.py
+++ b/src/cli.py
@@ -138,7 +138,7 @@ def scan(
         market,
         payload=payload,
     )
-    click.echo(json.dumps(result, indent=2))
+    click.echo(json.dumps(result.model_dump(by_alias=True), indent=2))
 
 
 @cli.command()

--- a/tests/test_additional_api_cases.py
+++ b/tests/test_additional_api_cases.py
@@ -15,6 +15,10 @@ def test_scan_request_exception(tv_api_mock):
         "https://scanner.tradingview.com/crypto/scan",
         exc=requests.exceptions.ConnectTimeout,
     )
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/crypto/scan",
+        exc=requests.exceptions.ConnectTimeout,
+    )
     api = TradingViewAPI()
     with pytest.raises(requests.exceptions.RequestException):
         api.scan("crypto", {})

--- a/tests/test_stock_data.py
+++ b/tests/test_stock_data.py
@@ -52,5 +52,9 @@ def test_fetch_recommend_http_error(tv_api_mock):
         "https://scanner.tradingview.com/stocks/scan",
         status_code=404,
     )
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/stocks/scan",
+        status_code=404,
+    )
     with pytest.raises(ValueError):
         fetch_recommendation("AAPL")

--- a/tests/test_tradingview_api.py
+++ b/tests/test_tradingview_api.py
@@ -27,7 +27,9 @@ def test_scan_and_metainfo(tv_api_mock, scope):
     )
 
     api = TradingViewAPI()
-    assert api.scan(scope, {}) == {"count": 0, "data": []}
+    scan = api.scan(scope, {})
+    assert scan.count == 0
+    assert scan.data == []
     assert api.metainfo(scope, {"query": ""}) == {"fields": []}
 
     tv_api_mock.post(
@@ -54,10 +56,13 @@ def test_scan_error(tv_api_mock):
         "https://scanner.tradingview.com/crypto/scan",
         status_code=404,
     )
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/crypto/scan",
+        json={"count": 0, "data": []},
+    )
     api = TradingViewAPI()
-    with pytest.raises(ValueError) as exc:
-        api.scan("crypto", {})
-    assert "TradingView HTTP 404" in str(exc.value)
+    result = api.scan("crypto", {})
+    assert result.count == 0
 
 
 def test_scan_invalid_json(tv_api_mock):
@@ -65,9 +70,13 @@ def test_scan_invalid_json(tv_api_mock):
         "https://scanner.tradingview.com/crypto/scan",
         text="not-json",
     )
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/crypto/scan",
+        json={"count": 0, "data": []},
+    )
     api = TradingViewAPI()
-    with pytest.raises(ValueError):
-        api.scan("crypto", {})
+    result = api.scan("crypto", {})
+    assert result.count == 0
 
 
 def test_scan_invalid_schema(tv_api_mock):


### PR DESCRIPTION
## Summary
- add GET fallback logic to `TradingViewAPI.scan`
- adapt stock utilities and CLI for new ScanResponse return type
- update unit tests for GET fallback behavior

## Testing
- `black . --check`
- `mypy src/`
- `pytest -q`
- `python codex_actions.py generate_openapi_spec`
- `python codex_actions.py validate_spec`


------
https://chatgpt.com/codex/tasks/task_e_684ee53f6cfc832cb35ef6005c4e590d