### PR TITLE
Add column validation in full_scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.40
+- Version bump
 ## 1.0.39
 - Version bump
 ## 1.0.38

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.39"
+version = "1.0.40"
 requires-python = ">=3.10"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.38
+  version: 1.0.39
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/tests/test_additional_api_cases.py
+++ b/tests/test_additional_api_cases.py
@@ -36,7 +36,12 @@ def test_fetch_metainfo_invalid_structure(tv_api_mock):
 def test_full_scan_auto_tickers(tv_api_mock, monkeypatch):
     tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/metainfo",
-        json={"fields": [{"name": "symbol", "type": "string"}]},
+        json={
+            "fields": [
+                {"name": "symbol", "type": "string"},
+                {"name": "c1", "type": "number"},
+            ]
+        },
     )
     tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
@@ -44,10 +49,14 @@ def test_full_scan_auto_tickers(tv_api_mock, monkeypatch):
     )
     monkeypatch.setattr(data_fetcher, "choose_tickers", lambda meta, limit=10: ["AAA"])
     result = full_scan("stocks", ["AUTO"], ["c1"])
-    assert result == {"count": 1, "data": [{"s": "AAA", "d": [1]}]}
+    assert result == {"count": 1, "data": [{"s": "AAA", "d": [1]}], "columns": ["c1"]}
 
 
 def test_full_scan_invalid_json(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/metainfo",
+        json={"fields": [{"name": "c1", "type": "number"}]},
+    )
     tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         text="oops",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,30 @@
+import pytest
+from src.api.data_fetcher import full_scan
+
+
+def test_full_scan_filters_invalid_fields(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/metainfo",
+        json={
+            "fields": [{"name": "close", "type": "number"}],
+            "filter": {"fields": [{"name": "open", "type": "number"}]},
+        },
+    )
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/scan",
+        json={"count": 1, "data": [{"s": "AAA", "d": [1, 2]}]},
+    )
+    result = full_scan("stocks", ["AAA"], ["close", "open", "bad"])
+    assert tv_api_mock.request_history[-1].json()["columns"] == ["close", "open"]
+    assert result["columns"] == ["close", "open"]
+
+
+def test_full_scan_all_invalid(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/metainfo",
+        json={"fields": [{"name": "close", "type": "number"}]},
+    )
+    with pytest.raises(ValueError):
+        full_scan("stocks", ["AAA"], ["bad"])
+    # ensure scan endpoint not called
+    assert len(tv_api_mock.request_history) == 1

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -41,6 +41,15 @@ def test_fetch_metainfo_invalid_json(tv_api_mock):
 
 def test_full_scan_single_batch(tv_api_mock):
     tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/metainfo",
+        json={
+            "fields": [
+                {"name": "c1", "type": "number"},
+                {"name": "c2", "type": "number"},
+            ]
+        },
+    )
+    tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         json={"count": 1, "data": [{"s": "AAA", "d": [1, 2]}]},
     )
@@ -49,6 +58,15 @@ def test_full_scan_single_batch(tv_api_mock):
 
 
 def test_full_scan_multi_batch(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/metainfo",
+        json={
+            "fields": [
+                {"name": f"c{i}", "type": "number"}
+                for i in range(MAX_COLUMNS_PER_SCAN + 1)
+            ]
+        },
+    )
     first = {"count": 1, "data": [{"s": "AAA", "d": list(range(MAX_COLUMNS_PER_SCAN))}]}
     second = {"count": 1, "data": [{"s": "AAA", "d": [99]}]}
     tv_api_mock.post(
@@ -61,6 +79,15 @@ def test_full_scan_multi_batch(tv_api_mock):
 
 
 def test_full_scan_batch_reorder(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/metainfo",
+        json={
+            "fields": [
+                {"name": f"c{i}", "type": "number"}
+                for i in range(MAX_COLUMNS_PER_SCAN + 1)
+            ]
+        },
+    )
     first = {
         "count": 2,
         "data": [
@@ -87,6 +114,10 @@ def test_full_scan_batch_reorder(tv_api_mock):
 
 
 def test_full_scan_error(tv_api_mock):
+    tv_api_mock.post(
+        "https://scanner.tradingview.com/stocks/metainfo",
+        json={"fields": [{"name": "c1", "type": "number"}]},
+    )
     tv_api_mock.post(
         "https://scanner.tradingview.com/stocks/scan",
         status_code=404,


### PR DESCRIPTION
## Summary
- validate requested scan fields using latest metainfo
- include filtered columns in scan results
- test invalid columns are dropped
- update tests for metainfo calls
- bump version to 1.0.40

## Testing
- `black . --check`
- `PYTHONPATH=$PWD pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684ee84b72b0832cb0ee998da4dc13c8