### PR TITLE
Update Numeric field enums and add numeric endpoint

### DIFF
--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.39
+  version: 1.0.40
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -98,6 +98,35 @@ paths:
           description: Bad Request
         '500':
           description: Server Error
+  /crypto/numeric:
+    get:
+      summary: Get numeric field for crypto
+      operationId: CryptoNumeric
+      x-openai-isConsequential: false
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: field
+          in: query
+          required: true
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Num'
+        '400':
+          description: Bad Request
+        '500':
+          description: Server Error
   /crypto/metainfo:
     post:
       summary: Get crypto metainfo
@@ -135,7 +164,8 @@ components:
         - close
     NumericFieldWithTimeframe:
       type: string
-      pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
+      enum: []
+      pattern: ^[A-Za-z0-9_.\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
     CryptoFields:
       type: object
       properties:

--- a/src/api/tradingview_api.py
+++ b/src/api/tradingview_api.py
@@ -132,7 +132,8 @@ class TradingViewAPI:
                 exc.response.text if exc.response else "",
             )
             raise ValueError(
-                f"TradingView HTTP {status}: {exc.response.text if exc.response else ''}"
+                f"TradingView HTTP {status}: "
+                f"{exc.response.text if exc.response else ''}"
             ) from exc
         except requests.ConnectionError:
             return _scan_get()

--- a/tests/test_metainfo_validation.py
+++ b/tests/test_metainfo_validation.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 from click.testing import CliRunner
-from pydantic import ValidationError
 
 from src.cli import cli
 from src.api.tradingview_api import TradingViewAPI

--- a/tests/test_yaml_generator.py
+++ b/tests/test_yaml_generator.py
@@ -56,7 +56,7 @@ def test_numeric_field_components() -> None:
     data = yaml.safe_load(yaml_str)
     schemas = data["components"]["schemas"]
     assert schemas["NumericFieldNoTimeframe"]["enum"] == []
-    assert "pattern" in schemas["NumericFieldWithTimeframe"]
+    assert "RSI|1D" in schemas["NumericFieldWithTimeframe"]["enum"]
 
 
 def test_symbol_field_ignored() -> None:
@@ -77,12 +77,12 @@ def test_collect_and_build_components() -> None:
     fields = [TVField(name="RSI|1D", type="number")]
     meta = MetaInfoResponse(data=fields)
     scan = {"data": [{"d": [55]}]}
-    collected, no_tf = collect_field_schemas(meta, scan)
+    collected, no_tf, with_tf = collect_field_schemas(meta, scan)
     assert collected[0][0] == "RSI|1D"
     assert "description" in collected[0][1]
     assert no_tf == set()
 
-    components = build_components_schemas("Crypto", collected, no_tf)
+    components = build_components_schemas("Crypto", collected, no_tf, with_tf)
     assert "CryptoFields" in components
     assert "NumericFieldNoTimeframe" in components
 
@@ -91,6 +91,7 @@ def test_build_paths_section() -> None:
     paths = build_paths_section("crypto", "Crypto")
     assert "/crypto/scan" in paths
     assert "/crypto/metainfo" in paths
+    assert "/crypto/numeric" in paths
 
 
 def test_fields_split_into_parts() -> None:


### PR DESCRIPTION
## Summary
- track numeric field enums with and without timeframe
- expose new `/numeric` GET endpoint in YAML generation
- adjust enum pattern and add numeric values to spec
- keep flake8 happy and update tests

## Testing
- `black .`
- `flake8 .`
- `mypy src`
- `PYTHONPATH=$PWD pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684ef302f7e4832c8bc7c63e818a5550