### PR TITLE
Add generate --market all support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "
 tvgen = "src.cli:cli"
 
 [tool.setuptools]
-packages = [ "src", "src.api", "src.generator", "src.utils", "src.constants",]
+packages = [ "src", "src.api", "src.generator", "src.utils", "src.constants", "src.spec",]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/src/spec/__init__.py
+++ b/src/spec/__init__.py
@@ -1,0 +1,5 @@
+"""Helpers for OpenAPI spec generation."""
+
+from .generator import generate_spec_for_all_markets, detect_all_markets
+
+__all__ = ["generate_spec_for_all_markets", "detect_all_markets"]

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from src.generator.yaml_generator import generate_for_market
+
+
+def detect_all_markets(indir: str | Path) -> List[str]:
+    """Return list of markets found under ``indir`` directory."""
+    base = Path(indir)
+    markets = [p.parent.name for p in base.glob("*/metainfo.json")]
+    markets.sort()
+    return markets
+
+
+def generate_spec_for_all_markets(
+    indir: Path, outdir: Path, max_size: int = 1_048_576
+) -> List[Path]:
+    """Generate specs for all markets under ``indir``."""
+    out_files: List[Path] = []
+    for market in detect_all_markets(indir):
+        out_files.append(generate_for_market(market, indir, outdir, max_size))
+    return out_files

--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -166,3 +166,19 @@ def test_preview_missing() -> None:
     result = runner.invoke(cli, ["preview", "--spec", "missing.yaml"])
     assert result.exit_code != 0
     assert "No such file" in result.output
+
+
+def test_generate_all(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        for m in ["crypto", "forex", "stocks"]:
+            _create_metainfo(Path("results") / m / "metainfo.json")
+        result = runner.invoke(
+            cli,
+            ["generate", "--market", "all", "--indir", "results", "--outdir", "specs"],
+        )
+        assert result.exit_code == 0, result.output
+        files = {p.name for p in Path("specs").glob("*.yaml")}
+        assert {"crypto.yaml", "forex.yaml", "stocks.yaml"}.issubset(files)
+        assert len(files) >= 3
+        assert "Generated" in result.output


### PR DESCRIPTION
## Summary
- support generating specs for all markets in CLI
- add helper module for spec generation
- include new test for `--market all`

## Testing
- `black . --quiet`
- `flake8 .`
- `mypy src/`
- `PYTHONPATH=$PWD pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684f1436160c832c84ac9ce33ffb8976