### PR TITLE
Add spec validation workflow

### DIFF
--- a/.github/workflows/validate-specs.yml
+++ b/.github/workflows/validate-specs.yml
@@ -1,0 +1,39 @@
+---
+name: Validate All OpenAPI Specs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Generate all specs
+        run: |
+          tvgen generate --market all --outdir specs
+
+      - name: Validate OpenAPI specs
+        run: |
+          failed=0
+          for file in specs/*.yaml; do
+            echo "🔍 Validating $file"
+            python -m openapi_spec_validator "$file" || failed=1
+          done
+          exit $failed
+


### PR DESCRIPTION
## Summary
- add workflow `validate-specs.yml` to generate and validate specs for all markets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f19118e54832c9eb384883cbda4b2