### PR TITLE
Add debug command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.41
+- Version bump
 ## 1.0.40
 - Version bump
 ## 1.0.39

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ docker run --rm ghcr.io/<owner>/tv-generator:latest \
 | generate        | build OpenAPI spec                            | `--market`, `--indir` results, `--outdir` specs, `--max-size` 1048576 |
 | validate        | validate spec file                            | `--spec` |
 | preview         | show fields summary from spec                 | `--spec` |
+| debug           | diagnose TradingView connectivity             | `--market`, `--verbose` |
 
 ### Short Examples
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.40"
+version = "1.0.41"
 requires-python = ">=3.10"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/america.yaml
+++ b/specs/america.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView America API
-  version: 1.0.36
+  version: 1.0.41
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -98,6 +98,35 @@ paths:
           description: Bad Request
         '500':
           description: Server Error
+  /america/numeric:
+    get:
+      summary: Get numeric field for america
+      operationId: AmericaNumeric
+      x-openai-isConsequential: false
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: field
+          in: query
+          required: true
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Num'
+        '400':
+          description: Bad Request
+        '500':
+          description: Server Error
   /america/metainfo:
     post:
       summary: Get america metainfo
@@ -135,7 +164,8 @@ components:
         - close
     NumericFieldWithTimeframe:
       type: string
-      pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
+      enum: []
+      pattern: ^[A-Za-z0-9_.\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
     AmericaFields:
       type: object
       properties:

--- a/specs/bond.yaml
+++ b/specs/bond.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Bond API
-  version: 1.0.36
+  version: 1.0.41
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -98,6 +98,35 @@ paths:
           description: Bad Request
         '500':
           description: Server Error
+  /bond/numeric:
+    get:
+      summary: Get numeric field for bond
+      operationId: BondNumeric
+      x-openai-isConsequential: false
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: field
+          in: query
+          required: true
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Num'
+        '400':
+          description: Bad Request
+        '500':
+          description: Server Error
   /bond/metainfo:
     post:
       summary: Get bond metainfo
@@ -135,7 +164,8 @@ components:
         - close
     NumericFieldWithTimeframe:
       type: string
-      pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
+      enum: []
+      pattern: ^[A-Za-z0-9_.\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
     BondFields:
       type: object
       properties:

--- a/specs/cfd.yaml
+++ b/specs/cfd.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Cfd API
-  version: 1.0.36
+  version: 1.0.41
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -98,6 +98,35 @@ paths:
           description: Bad Request
         '500':
           description: Server Error
+  /cfd/numeric:
+    get:
+      summary: Get numeric field for cfd
+      operationId: CfdNumeric
+      x-openai-isConsequential: false
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: field
+          in: query
+          required: true
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Num'
+        '400':
+          description: Bad Request
+        '500':
+          description: Server Error
   /cfd/metainfo:
     post:
       summary: Get cfd metainfo
@@ -135,7 +164,8 @@ components:
         - close
     NumericFieldWithTimeframe:
       type: string
-      pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
+      enum: []
+      pattern: ^[A-Za-z0-9_.\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
     CfdFields:
       type: object
       properties:

--- a/specs/coin.yaml
+++ b/specs/coin.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Coin API
-  version: 1.0.36
+  version: 1.0.41
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -98,6 +98,35 @@ paths:
           description: Bad Request
         '500':
           description: Server Error
+  /coin/numeric:
+    get:
+      summary: Get numeric field for coin
+      operationId: CoinNumeric
+      x-openai-isConsequential: false
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: field
+          in: query
+          required: true
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Num'
+        '400':
+          description: Bad Request
+        '500':
+          description: Server Error
   /coin/metainfo:
     post:
       summary: Get coin metainfo
@@ -135,7 +164,8 @@ components:
         - close
     NumericFieldWithTimeframe:
       type: string
-      pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
+      enum: []
+      pattern: ^[A-Za-z0-9_.\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
     CoinFields:
       type: object
       properties:

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.40
+  version: 1.0.41
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/forex.yaml
+++ b/specs/forex.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Forex API
-  version: 1.0.36
+  version: 1.0.41
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -98,6 +98,35 @@ paths:
           description: Bad Request
         '500':
           description: Server Error
+  /forex/numeric:
+    get:
+      summary: Get numeric field for forex
+      operationId: ForexNumeric
+      x-openai-isConsequential: false
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: field
+          in: query
+          required: true
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Num'
+        '400':
+          description: Bad Request
+        '500':
+          description: Server Error
   /forex/metainfo:
     post:
       summary: Get forex metainfo
@@ -135,7 +164,8 @@ components:
         - close
     NumericFieldWithTimeframe:
       type: string
-      pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
+      enum: []
+      pattern: ^[A-Za-z0-9_.\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
     ForexFields:
       type: object
       properties:

--- a/specs/futures.yaml
+++ b/specs/futures.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Futures API
-  version: 1.0.36
+  version: 1.0.41
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -98,6 +98,35 @@ paths:
           description: Bad Request
         '500':
           description: Server Error
+  /futures/numeric:
+    get:
+      summary: Get numeric field for futures
+      operationId: FuturesNumeric
+      x-openai-isConsequential: false
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: field
+          in: query
+          required: true
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Num'
+        '400':
+          description: Bad Request
+        '500':
+          description: Server Error
   /futures/metainfo:
     post:
       summary: Get futures metainfo
@@ -135,7 +164,8 @@ components:
         - close
     NumericFieldWithTimeframe:
       type: string
-      pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
+      enum: []
+      pattern: ^[A-Za-z0-9_.\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
     FuturesFields:
       type: object
       properties:

--- a/specs/stocks.yaml
+++ b/specs/stocks.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Stocks API
-  version: 1.0.36
+  version: 1.0.41
 servers:
   - url: https://scanner.tradingview.com
 paths:
@@ -98,6 +98,35 @@ paths:
           description: Bad Request
         '500':
           description: Server Error
+  /stocks/numeric:
+    get:
+      summary: Get numeric field for stocks
+      operationId: StocksNumeric
+      x-openai-isConsequential: false
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: field
+          in: query
+          required: true
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Num'
+        '400':
+          description: Bad Request
+        '500':
+          description: Server Error
   /stocks/metainfo:
     post:
       summary: Get stocks metainfo
@@ -135,7 +164,8 @@ components:
         - close
     NumericFieldWithTimeframe:
       type: string
-      pattern: ^[A-Z0-9_+\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
+      enum: []
+      pattern: ^[A-Za-z0-9_.\[\]]+\|(1|5|15|30|60|120|240|1D|1W)$
     StocksFields:
       type: object
       properties:

--- a/src/cli.py
+++ b/src/cli.py
@@ -524,5 +524,15 @@ def preview(spec_file: Path) -> None:
     click.echo(df.to_string(index=False))
 
 
+@cli.command()
+@click.option("--market", required=True, type=click.Choice(SCOPES), help="Market name")
+@click.option("--verbose", is_flag=True, help="Show full JSON output")
+def debug(market: str, verbose: bool) -> None:
+    """Diagnose TradingView connectivity for the given market."""
+
+    result = TradingViewAPI().diagnose_connection(market, verbose)
+    click.echo(result)
+
+
 if __name__ == "__main__":
     cli()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -540,3 +540,30 @@ def test_cli_validate_crypto_spec() -> None:
     result = runner.invoke(cli, ["validate", "--spec", str(spec)])
     assert result.exit_code == 0
     assert "Specification is valid" in result.output
+
+
+def test_cli_debug(tv_api_mock) -> None:
+    runner = CliRunner()
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/crypto/metainfo",
+        json={"version": 1, "filters": [], "columns": []},
+    )
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/crypto/scan",
+        json={"data": [], "columns": []},
+    )
+    result = runner.invoke(cli, ["debug", "--market", "crypto"])
+    assert result.exit_code == 0
+    assert "TradingView" in result.output
+    assert "[\u2713] GET /crypto/metainfo" in result.output
+
+
+def test_cli_debug_error(tv_api_mock) -> None:
+    runner = CliRunner()
+    tv_api_mock.get(
+        "https://scanner.tradingview.com/crypto/metainfo",
+        status_code=500,
+    )
+    result = runner.invoke(cli, ["debug", "--market", "crypto"])
+    assert result.exit_code == 0
+    assert "\u274c" in result.output


### PR DESCRIPTION
## Summary
- support new CLI command `debug` to test TradingView connectivity
- implement `TradingViewAPI.diagnose_connection`
- document `debug` command in README
- bump version to 1.0.41
- update generated specs
- test new functionality

## Testing
- `mypy src/`
- `PYTHONPATH=$PWD pytest -q`
- `python - <<'PY'
from codex_actions import generate_openapi_spec
generate_openapi_spec()
PY`
- `python - <<'PY'
from codex_actions import validate_spec
validate_spec()
PY`

------
https://chatgpt.com/codex/tasks/task_e_684f1ce60f2c832c8d941b6ac7ec3ef1