### PR TITLE
Add bundle CLI command

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -28,6 +28,7 @@ from src.api.data_fetcher import fetch_metainfo, full_scan, save_json, choose_ti
 from src.api.data_manager import build_field_status
 from src.models import TVField, MetaInfoResponse
 from src.constants import SCOPES
+from src.spec.bundler import bundle_all_specs
 import pandas as pd
 
 logger = logging.getLogger(__name__)
@@ -546,6 +547,29 @@ def preview(spec_file: Path) -> None:
 
     df = pd.DataFrame(rows, columns=["field", "type", "enum", "description"])
     click.echo(df.to_string(index=False))
+
+
+@cli.command()
+@click.option(
+    "--format",
+    "format_",
+    default="json",
+    show_default=True,
+    type=click.Choice(["json", "yaml"]),
+    help="Output format",
+)
+@click.option(
+    "--outfile", default="bundle.json", show_default=True, help="Bundle file path"
+)
+def bundle(format_: str, outfile: str) -> None:
+    """Bundle all specifications under ``specs/`` directory."""
+
+    try:
+        out_path = bundle_all_specs("specs/", outfile, format=format_)
+    except FileNotFoundError as exc:  # pragma: no cover - click handles output
+        raise click.ClickException(str(exc))
+    size_kb = Path(out_path).stat().st_size // 1024
+    click.echo(f"\u2713 {out_path} {size_kb} KB")
 
 
 @cli.command()

--- a/src/spec/__init__.py
+++ b/src/spec/__init__.py
@@ -5,9 +5,11 @@ from .generator import (
     generate_spec_for_market,
     detect_all_markets,
 )
+from .bundler import bundle_all_specs
 
 __all__ = [
     "generate_spec_for_all_markets",
     "generate_spec_for_market",
     "detect_all_markets",
+    "bundle_all_specs",
 ]

--- a/src/spec/bundler.py
+++ b/src/spec/bundler.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any
+import json
+import yaml
+
+
+def bundle_all_specs(
+    spec_dir: str | Path, outfile: str | Path, format: str = "json"
+) -> Path:
+    """Bundle all YAML specs under *spec_dir* into a single file.
+
+    Each ``*.yaml`` file is loaded and placed under a key named after the file
+    stem (market name). The resulting dictionary is written to ``outfile`` in
+    the requested *format* (``json`` or ``yaml``).
+    """
+
+    base = Path(spec_dir)
+    data: Dict[str, Any] = {}
+    for yaml_file in base.glob("*.yaml"):
+        with yaml_file.open("r", encoding="utf-8") as fh:
+            data[yaml_file.stem] = yaml.safe_load(fh)
+
+    out_path = Path(outfile)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if format == "json":
+        out_path.write_text(json.dumps(data, indent=2))
+    else:
+        out_path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return out_path

--- a/tests/test_cli_bundle.py
+++ b/tests/test_cli_bundle.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import json
+import yaml
+from click.testing import CliRunner
+
+from src.cli import cli
+
+ROOT_SPECS = Path(__file__).resolve().parents[1] / "specs"
+
+
+def _copy_specs(dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    for f in ROOT_SPECS.glob("*.yaml"):
+        dest.joinpath(f.name).write_text(f.read_text())
+
+
+def test_cli_bundle_json() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _copy_specs(Path("specs"))
+        result = runner.invoke(cli, ["bundle"])
+        assert result.exit_code == 0, result.output
+        out = Path("bundle.json")
+        data = json.loads(out.read_text())
+        assert "crypto" in data
+        assert isinstance(data["crypto"], dict)
+
+
+def test_cli_bundle_yaml() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _copy_specs(Path("specs"))
+        out_dir = Path("output")
+        result = runner.invoke(
+            cli,
+            ["bundle", "--format", "yaml", "--outfile", str(out_dir / "bundle.yaml")],
+        )
+        assert result.exit_code == 0, result.output
+        out_file = out_dir / "bundle.yaml"
+        data = yaml.safe_load(out_file.read_text())
+        assert "stocks" in data
+        assert isinstance(data["stocks"], dict)


### PR DESCRIPTION
## Summary
- add spec bundler utility
- expose bundler in src.spec
- implement `tvgen bundle` CLI command
- test bundler command

## Testing
- `black src/spec/bundler.py src/spec/__init__.py src/cli.py tests/test_cli_bundle.py`
- `flake8`
- `mypy src`
- `PYTHONPATH=$PWD pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684f21f65810832c81170702132f7805