### PR TITLE
Ensure OpenAPI specs include project version

### DIFF
--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, TYPE_CHECKING
 import json
 import re
 
-import toml
 import yaml
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
@@ -14,20 +13,13 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 from src.models import MetaInfoResponse, TVField, ScanResponse
 from src.api.tradingview_api import TradingViewAPI
 from src.utils import tv2ref
+from src.meta.versioning import get_current_version
 
 
 def get_project_version() -> str:
     """Return project version from pyproject.toml."""
 
-    root = Path(__file__).resolve().parents[2]
-    try:
-        data = toml.load(root / "pyproject.toml")
-    except FileNotFoundError as exc:  # pragma: no cover - missing pyproject
-        raise RuntimeError("Version not found in pyproject.toml") from exc
-    version = data.get("project", {}).get("version")
-    if not version:
-        raise RuntimeError("Version not found in pyproject.toml")
-    return str(version)
+    return get_current_version()
 
 
 def _supported_timeframes() -> list[str]:

--- a/src/meta/versioning.py
+++ b/src/meta/versioning.py
@@ -30,6 +30,12 @@ def get_version(path: Path | None = None) -> str:
     return str(version)
 
 
+def get_current_version() -> str:
+    """Return current project version using default pyproject path."""
+
+    return get_version()
+
+
 def _write_pyproject(data: dict, path: Path) -> None:
     path.write_text(toml.dumps(data))
 

--- a/tests/test_spec_version.py
+++ b/tests/test_spec_version.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+import yaml
+
+from src.spec.generator import generate_spec_for_market
+from src.meta import versioning
+
+
+def _create_metainfo(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"data": {"fields": [{"name": "close", "type": "integer"}]}}
+    path.write_text(json.dumps(data))
+    scan = {"count": 1, "data": [{"s": "AAA", "d": [1]}]}
+    (path.parent / "scan.json").write_text(json.dumps(scan))
+    tsv = "field\ttv_type\tstatus\tsample_value\nclose\tinteger\tok\t1\n"
+    (path.parent / "field_status.tsv").write_text(tsv)
+
+
+def test_spec_uses_current_version(tmp_path, monkeypatch) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\nversion = '2.0.0'\n")
+    monkeypatch.setattr(versioning, "DEFAULT_PYPROJECT_PATH", pyproject)
+
+    indir = tmp_path / "results"
+    _create_metainfo(indir / "crypto" / "metainfo.json")
+    outdir = tmp_path / "specs"
+
+    generate_spec_for_market("crypto", indir, outdir)
+
+    spec = yaml.safe_load((outdir / "crypto.yaml").read_text())
+    assert spec["info"]["version"] == versioning.get_current_version()


### PR DESCRIPTION
## Summary
- fetch current project version via `meta.versioning.get_current_version`
- use it when generating YAML specs
- add regression test for version in generated specs

## Testing
- `mypy src/`
- `PYTHONPATH=$PWD pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684f2a9062ec832c8e1ff6991337375e