### PR TITLE
Add scan audit and CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.0.42
+- Scan audit feature
+
 ## 1.0.41
 - Version bump
 ## 1.0.40

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.41"
+version = "1.0.42"
 requires-python = ">=3.10"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/america.yaml
+++ b/specs/america.yaml
@@ -2,9 +2,9 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView America API
-  version: 1.0.41
+  version: 1.0.42
 servers:
-  - url: https://scanner.tradingview.com
+- url: https://scanner.tradingview.com
 paths:
   /america/scan:
     post:
@@ -104,18 +104,18 @@ paths:
       operationId: AmericaNumeric
       x-openai-isConsequential: false
       parameters:
-        - name: symbol
-          in: query
-          required: true
-          schema:
-            type: string
-        - name: field
-          in: query
-          required: true
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
-              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      - name: symbol
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: field
+        in: query
+        required: true
+        schema:
+          oneOf:
+          - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+          - $ref: '#/components/schemas/NumericFieldNoTimeframe'
       responses:
         '200':
           description: Successful response
@@ -161,7 +161,7 @@ components:
     NumericFieldNoTimeframe:
       type: string
       enum:
-        - close
+      - close
     NumericFieldWithTimeframe:
       type: string
       enum: []
@@ -202,8 +202,8 @@ components:
         range:
           type: object
       required:
-        - symbols
-        - columns
+      - symbols
+      - columns
     AmericaScanResponse:
       type: object
       properties:

--- a/specs/bond.yaml
+++ b/specs/bond.yaml
@@ -2,9 +2,9 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Bond API
-  version: 1.0.41
+  version: 1.0.42
 servers:
-  - url: https://scanner.tradingview.com
+- url: https://scanner.tradingview.com
 paths:
   /bond/scan:
     post:
@@ -104,18 +104,18 @@ paths:
       operationId: BondNumeric
       x-openai-isConsequential: false
       parameters:
-        - name: symbol
-          in: query
-          required: true
-          schema:
-            type: string
-        - name: field
-          in: query
-          required: true
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
-              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      - name: symbol
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: field
+        in: query
+        required: true
+        schema:
+          oneOf:
+          - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+          - $ref: '#/components/schemas/NumericFieldNoTimeframe'
       responses:
         '200':
           description: Successful response
@@ -161,7 +161,7 @@ components:
     NumericFieldNoTimeframe:
       type: string
       enum:
-        - close
+      - close
     NumericFieldWithTimeframe:
       type: string
       enum: []
@@ -202,8 +202,8 @@ components:
         range:
           type: object
       required:
-        - symbols
-        - columns
+      - symbols
+      - columns
     BondScanResponse:
       type: object
       properties:

--- a/specs/cfd.yaml
+++ b/specs/cfd.yaml
@@ -2,9 +2,9 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Cfd API
-  version: 1.0.41
+  version: 1.0.42
 servers:
-  - url: https://scanner.tradingview.com
+- url: https://scanner.tradingview.com
 paths:
   /cfd/scan:
     post:
@@ -104,18 +104,18 @@ paths:
       operationId: CfdNumeric
       x-openai-isConsequential: false
       parameters:
-        - name: symbol
-          in: query
-          required: true
-          schema:
-            type: string
-        - name: field
-          in: query
-          required: true
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
-              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      - name: symbol
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: field
+        in: query
+        required: true
+        schema:
+          oneOf:
+          - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+          - $ref: '#/components/schemas/NumericFieldNoTimeframe'
       responses:
         '200':
           description: Successful response
@@ -161,7 +161,7 @@ components:
     NumericFieldNoTimeframe:
       type: string
       enum:
-        - close
+      - close
     NumericFieldWithTimeframe:
       type: string
       enum: []
@@ -202,8 +202,8 @@ components:
         range:
           type: object
       required:
-        - symbols
-        - columns
+      - symbols
+      - columns
     CfdScanResponse:
       type: object
       properties:

--- a/specs/coin.yaml
+++ b/specs/coin.yaml
@@ -2,9 +2,9 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Coin API
-  version: 1.0.41
+  version: 1.0.42
 servers:
-  - url: https://scanner.tradingview.com
+- url: https://scanner.tradingview.com
 paths:
   /coin/scan:
     post:
@@ -104,18 +104,18 @@ paths:
       operationId: CoinNumeric
       x-openai-isConsequential: false
       parameters:
-        - name: symbol
-          in: query
-          required: true
-          schema:
-            type: string
-        - name: field
-          in: query
-          required: true
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
-              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      - name: symbol
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: field
+        in: query
+        required: true
+        schema:
+          oneOf:
+          - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+          - $ref: '#/components/schemas/NumericFieldNoTimeframe'
       responses:
         '200':
           description: Successful response
@@ -161,7 +161,7 @@ components:
     NumericFieldNoTimeframe:
       type: string
       enum:
-        - close
+      - close
     NumericFieldWithTimeframe:
       type: string
       enum: []
@@ -202,8 +202,8 @@ components:
         range:
           type: object
       required:
-        - symbols
-        - columns
+      - symbols
+      - columns
     CoinScanResponse:
       type: object
       properties:

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,9 +2,9 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.41
+  version: 1.0.42
 servers:
-  - url: https://scanner.tradingview.com
+- url: https://scanner.tradingview.com
 paths:
   /crypto/scan:
     post:
@@ -104,18 +104,18 @@ paths:
       operationId: CryptoNumeric
       x-openai-isConsequential: false
       parameters:
-        - name: symbol
-          in: query
-          required: true
-          schema:
-            type: string
-        - name: field
-          in: query
-          required: true
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
-              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      - name: symbol
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: field
+        in: query
+        required: true
+        schema:
+          oneOf:
+          - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+          - $ref: '#/components/schemas/NumericFieldNoTimeframe'
       responses:
         '200':
           description: Successful response
@@ -161,7 +161,7 @@ components:
     NumericFieldNoTimeframe:
       type: string
       enum:
-        - close
+      - close
     NumericFieldWithTimeframe:
       type: string
       enum: []
@@ -205,8 +205,8 @@ components:
         range:
           type: object
       required:
-        - symbols
-        - columns
+      - symbols
+      - columns
     CryptoScanResponse:
       type: object
       properties:

--- a/specs/forex.yaml
+++ b/specs/forex.yaml
@@ -2,9 +2,9 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Forex API
-  version: 1.0.41
+  version: 1.0.42
 servers:
-  - url: https://scanner.tradingview.com
+- url: https://scanner.tradingview.com
 paths:
   /forex/scan:
     post:
@@ -104,18 +104,18 @@ paths:
       operationId: ForexNumeric
       x-openai-isConsequential: false
       parameters:
-        - name: symbol
-          in: query
-          required: true
-          schema:
-            type: string
-        - name: field
-          in: query
-          required: true
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
-              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      - name: symbol
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: field
+        in: query
+        required: true
+        schema:
+          oneOf:
+          - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+          - $ref: '#/components/schemas/NumericFieldNoTimeframe'
       responses:
         '200':
           description: Successful response
@@ -161,7 +161,7 @@ components:
     NumericFieldNoTimeframe:
       type: string
       enum:
-        - close
+      - close
     NumericFieldWithTimeframe:
       type: string
       enum: []
@@ -202,8 +202,8 @@ components:
         range:
           type: object
       required:
-        - symbols
-        - columns
+      - symbols
+      - columns
     ForexScanResponse:
       type: object
       properties:

--- a/specs/futures.yaml
+++ b/specs/futures.yaml
@@ -2,9 +2,9 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Futures API
-  version: 1.0.41
+  version: 1.0.42
 servers:
-  - url: https://scanner.tradingview.com
+- url: https://scanner.tradingview.com
 paths:
   /futures/scan:
     post:
@@ -104,18 +104,18 @@ paths:
       operationId: FuturesNumeric
       x-openai-isConsequential: false
       parameters:
-        - name: symbol
-          in: query
-          required: true
-          schema:
-            type: string
-        - name: field
-          in: query
-          required: true
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
-              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      - name: symbol
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: field
+        in: query
+        required: true
+        schema:
+          oneOf:
+          - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+          - $ref: '#/components/schemas/NumericFieldNoTimeframe'
       responses:
         '200':
           description: Successful response
@@ -161,7 +161,7 @@ components:
     NumericFieldNoTimeframe:
       type: string
       enum:
-        - close
+      - close
     NumericFieldWithTimeframe:
       type: string
       enum: []
@@ -202,8 +202,8 @@ components:
         range:
           type: object
       required:
-        - symbols
-        - columns
+      - symbols
+      - columns
     FuturesScanResponse:
       type: object
       properties:

--- a/specs/stocks.yaml
+++ b/specs/stocks.yaml
@@ -2,9 +2,9 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Stocks API
-  version: 1.0.41
+  version: 1.0.42
 servers:
-  - url: https://scanner.tradingview.com
+- url: https://scanner.tradingview.com
 paths:
   /stocks/scan:
     post:
@@ -104,18 +104,18 @@ paths:
       operationId: StocksNumeric
       x-openai-isConsequential: false
       parameters:
-        - name: symbol
-          in: query
-          required: true
-          schema:
-            type: string
-        - name: field
-          in: query
-          required: true
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/NumericFieldWithTimeframe'
-              - $ref: '#/components/schemas/NumericFieldNoTimeframe'
+      - name: symbol
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: field
+        in: query
+        required: true
+        schema:
+          oneOf:
+          - $ref: '#/components/schemas/NumericFieldWithTimeframe'
+          - $ref: '#/components/schemas/NumericFieldNoTimeframe'
       responses:
         '200':
           description: Successful response
@@ -161,7 +161,7 @@ components:
     NumericFieldNoTimeframe:
       type: string
       enum:
-        - close
+      - close
     NumericFieldWithTimeframe:
       type: string
       enum: []
@@ -202,8 +202,8 @@ components:
         range:
           type: object
       required:
-        - symbols
-        - columns
+      - symbols
+      - columns
     StocksScanResponse:
       type: object
       properties:

--- a/src/analyzer/scan_audit.py
+++ b/src/analyzer/scan_audit.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+
+__all__ = ["find_missing_fields"]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def _extract_strings(obj: Any) -> Iterable[str]:
+    if isinstance(obj, dict):
+        for val in obj.values():
+            yield from _extract_strings(val)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _extract_strings(item)
+    elif isinstance(obj, str):
+        yield obj
+
+
+def _collect_scan_fields(scan: dict[str, Any]) -> set[str]:
+    fields: set[str] = set()
+    columns = scan.get("columns")
+    if isinstance(columns, list):
+        fields.update(str(c) for c in columns if isinstance(c, str))
+    for key in ("filter", "filter2", "sort"):
+        obj = scan.get(key)
+        if isinstance(obj, (dict, list)):
+            for token in _extract_strings(obj):
+                if token and " " not in token and "/" not in token:
+                    fields.add(token)
+    return fields
+
+
+def _infer_type(value: Any) -> str:
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "numeric"
+    return "string"
+
+
+def _infer_field_type(field: str, scan: dict[str, Any]) -> str:
+    columns = scan.get("columns")
+    if isinstance(columns, list) and field in columns:
+        idx = columns.index(field)
+        rows = scan.get("data", [])
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            dval = row.get("d")
+            if isinstance(dval, list) and idx < len(dval):
+                val = dval[idx]
+                if val not in (None, ""):
+                    return _infer_type(val)
+    return "string"
+
+
+def find_missing_fields(
+    meta: dict[str, Any] | Path,
+    scan: dict[str, Any] | Path,
+    status: pd.DataFrame | Path | None = None,
+) -> list[dict[str, str]]:
+    """Return list of fields used in scan but absent from metainfo."""
+
+    if isinstance(meta, Path):
+        meta = _load_json(meta)
+    if isinstance(scan, Path):
+        scan = _load_json(scan)
+
+    meta_fields: set[str] = set()
+    for item in meta.get("fields", []) + meta.get("data", {}).get("fields", []):
+        name = None
+        if isinstance(item, dict):
+            name = item.get("name") or item.get("id")
+        elif hasattr(item, "get"):
+            name = item.get("name") or item.get("id")
+        if isinstance(name, str):
+            meta_fields.add(name)
+
+    status_fields: set[str] = set()
+    if isinstance(status, pd.DataFrame):
+        status_fields = set(status.get("field", []))
+    elif isinstance(status, Path) and status.exists():
+        try:
+            df = pd.read_csv(status, sep="\t")
+        except Exception:
+            df = pd.DataFrame()
+        status_fields = {str(v).strip() for v in df.get("field", [])}
+
+    known = meta_fields | status_fields
+    used = _collect_scan_fields(scan)
+    missing = sorted(used - known)
+
+    result: list[dict[str, str]] = []
+    for name in missing:
+        ftype = _infer_field_type(name, scan)
+        result.append({"name": name, "source": "scan", "type": ftype})
+    return result

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -18,18 +18,33 @@ def detect_all_markets(indir: str | Path) -> List[str]:
 
 
 def generate_spec_for_all_markets(
-    indir: Path, outdir: Path, max_size: int = 1_048_576
+    indir: Path,
+    outdir: Path,
+    max_size: int = 1_048_576,
+    *,
+    include_missing: bool = False,
 ) -> List[Path]:
     """Generate specs for all markets under ``indir``."""
     out_files: List[Path] = []
     for market in detect_all_markets(indir):
-        out_files.append(generate_spec_for_market(market, indir, outdir, max_size))
+        out_files.append(
+            generate_spec_for_market(
+                market, indir, outdir, max_size, include_missing=include_missing
+            )
+        )
     return out_files
 
 
 def generate_spec_for_market(
-    market: str, indir: Path, outdir: Path, max_size: int = 1_048_576
+    market: str,
+    indir: Path,
+    outdir: Path,
+    max_size: int = 1_048_576,
+    *,
+    include_missing: bool = False,
 ) -> Path:
     """Generate spec for a single market."""
 
-    return generate_for_market(market, indir, outdir, max_size)
+    return generate_for_market(
+        market, indir, outdir, max_size, include_missing=include_missing
+    )

--- a/tests/test_scan_audit.py
+++ b/tests/test_scan_audit.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+from src.analyzer.scan_audit import find_missing_fields
+
+
+def test_find_missing_fields(tmp_path: Path) -> None:
+    meta = {"data": {"fields": [{"name": "close", "type": "number"}]}}
+    scan = {"columns": ["close", "Custom"], "data": [{"s": "AAA", "d": [1, 2]}]}
+    meta_path = tmp_path / "metainfo.json"
+    scan_path = tmp_path / "scan.json"
+    meta_path.write_text(json.dumps(meta))
+    scan_path.write_text(json.dumps(scan))
+
+    missing = find_missing_fields(meta_path, scan_path)
+    assert missing == [{"name": "Custom", "source": "scan", "type": "numeric"}]
+
+
+def test_find_missing_fields_ignore_status(tmp_path: Path) -> None:
+    meta = {"fields": [{"name": "a", "type": "number"}]}
+    scan = {"columns": ["a", "b"], "data": [{"s": "A", "d": [1, 3]}]}
+    status_path = tmp_path / "field_status.tsv"
+    status_path.write_text("field\ttv_type\n b\tnumber\n")
+    meta_path = tmp_path / "metainfo.json"
+    scan_path = tmp_path / "scan.json"
+    meta_path.write_text(json.dumps(meta))
+    scan_path.write_text(json.dumps(scan))
+
+    missing = find_missing_fields(meta_path, scan_path, status_path)
+    assert missing == []


### PR DESCRIPTION
## Summary
- add scan_audit module to detect fields absent from metainfo
- expose `audit-missing-fields` command in CLI
- support `--include-missing` in spec generation
- include MissingFields schema when requested
- bump version to 1.0.42
- document feature in changelog
- test the scan audit logic

## Testing
- `black src tests -q`
- `flake8`
- `mypy src`
- `PYTHONPATH=$PWD pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684f2d6145b4832cab347c08296c5b61