### PR TITLE
Implement generate-if-needed command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.48
+- Version bump
 ## 1.0.47
 - Add diff command and cache comparison
 

--- a/README.md
+++ b/README.md
@@ -22,29 +22,30 @@ tvgen validate --spec specs/crypto.yaml
 
 ## 🛠️ CLI команды
 
+- `audit-missing-fields` - Show fields present in scan.json but missing from metainfo.
 - `build` - Collect data and generate specs for all markets.
 - `build-all` - Collect data and generate specs for all markets.
+- `bump-version` - Increment project version.
 - `bundle` - Bundle all specifications under ``specs/`` directory.
+- `changelog` - Generate CHANGELOG from git history.
 - `collect` - Fetch metainfo and scan results saving JSON and TSV.
-- `refresh` - Update metainfo, scan.json and field_status.tsv for markets.
-- `diff` - Compare results with cached versions.
 - `debug` - Diagnose TradingView connectivity for the given market.
-- `changelog` - Generate `CHANGELOG.md` from git history.
+- `diff` - Compare results with cached versions.
+- `docs` - Generate README file with CLI command list.
 - `generate` - Generate OpenAPI YAML using collected JSON and TSV.
-- `version` - Print current project version.
-- `bump-version` - Increment version in `pyproject.toml`.
+- `generate-if-needed` - Generate specs only when diff finds changes.
 - `history` - Call /{market}/history with the given payload.
+- `list-fields` - List fields grouped by classification.
 - `metainfo` - Fetch metainfo for given market via /{market}/metainfo.
 - `preview` - Show table with fields, type, enum and description.
 - `price` - Fetch last close price for a symbol.
 - `recommend` - Fetch trading recommendation for a symbol.
+- `refresh` - Download latest data and update TSV files.
 - `scan` - Perform a basic scan request and print JSON.
 - `search` - Call /{market}/search with the given payload.
 - `summary` - Call /{market}/summary with the given payload.
 - `validate` - Validate an OpenAPI specification file.
-
-Use `refresh` to ensure the latest TradingView data is saved before running
-`generate`. It overwrites existing JSON files for the chosen markets.
+- `version` - Show current package version.
 
 ## 📁 Структура проекта
 
@@ -52,33 +53,13 @@ Use `refresh` to ensure the latest TradingView data is saved before running
 - `results/` — сохранённые ответы TradingView
 - `specs/` — итоговые спецификации OpenAPI
 
-CI автоматически добавляет `CHANGELOG.md` в артефакты релиза и вызывает
-`tvgen changelog` перед загрузкой спецификаций.
-
 ## 🎯 Цель
 
 Генерация OpenAPI 3.1 спецификаций на основе TradingView.
-
 
 ## Timeframe codes
 ```
 1, 5, 15, 30, 60, 120, 240   -> minutes
 1D                          -> 1 day
 1W                          -> 1 week
-```
-
-## Отслеживание изменений (`tvgen diff`)
-
-Команда `tvgen diff` сравнивает файлы в каталоге `results/` с предыдущими
-копиями из `cache/`. Это позволяет увидеть новые или удалённые поля после
-обновления данных.
-
-```bash
-tvgen diff --market crypto
-```
-
-Отчёт можно сохранить в файл:
-
-```bash
-tvgen diff --market all --output diff.md
 ```

--- a/codex_actions.py
+++ b/codex_actions.py
@@ -111,6 +111,29 @@ def format_code():
         raise
 
 
+def generate_if_needed() -> None:
+    """Run conditional generation for all markets."""
+
+    try:
+        subprocess.run(
+            [
+                "tvgen",
+                "generate-if-needed",
+                "--market",
+                "all",
+                "--bundle",
+                "--validate",
+            ],
+            check=True,
+        )
+    except FileNotFoundError:
+        print("tvgen command not found", file=sys.stderr)
+        raise
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr, file=sys.stderr)
+        raise
+
+
 def bump_version():
     """Bump patch version in pyproject.toml and update CHANGELOG."""
     import toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.47"
+version = "1.0.48"
 requires-python = ">=3.10"
 dependencies = [ "click>=8.2", "requests>=2.32", "pandas>=2.3", "PyYAML>=6.0", "openapi-spec-validator>=0.7", "toml>=0.10", "requests_cache>=1.2", "pydantic>=2.7",]
 

--- a/specs/america.yaml
+++ b/specs/america.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView America API
-  version: 1.0.46
+  version: 1.0.48
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/bond.yaml
+++ b/specs/bond.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Bond API
-  version: 1.0.46
+  version: 1.0.48
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/cfd.yaml
+++ b/specs/cfd.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Cfd API
-  version: 1.0.46
+  version: 1.0.48
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/coin.yaml
+++ b/specs/coin.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Coin API
-  version: 1.0.46
+  version: 1.0.48
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/crypto.yaml
+++ b/specs/crypto.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Crypto API
-  version: 1.0.47
+  version: 1.0.48
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/forex.yaml
+++ b/specs/forex.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Forex API
-  version: 1.0.46
+  version: 1.0.48
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/futures.yaml
+++ b/specs/futures.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Futures API
-  version: 1.0.46
+  version: 1.0.48
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/specs/stocks.yaml
+++ b/specs/stocks.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 x-oai-custom-action-schema-version: v1
 info:
   title: Unofficial TradingView Stocks API
-  version: 1.0.46
+  version: 1.0.48
 servers:
   - url: https://scanner.tradingview.com
 paths:

--- a/tests/test_conditional_generate.py
+++ b/tests/test_conditional_generate.py
@@ -1,0 +1,88 @@
+from click.testing import CliRunner
+from pathlib import Path
+import json
+
+from src.cli import cli
+
+
+def _create_market(path: Path, fields: list[tuple[str, str]]) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    meta = {"fields": [{"name": f, "type": t} for f, t in fields]}
+    (path / "metainfo.json").write_text(json.dumps(meta))
+    scan = {"count": 1, "data": [{"s": "AAA", "d": [1 for _ in fields]}]}
+    (path / "scan.json").write_text(json.dumps(scan))
+    lines = ["field\ttv_type\tstatus\tsample_value"]
+    for f, t in fields:
+        lines.append(f"{f}\t{t}\tok\t1")
+    (path / "field_status.tsv").write_text("\n".join(lines) + "\n")
+
+
+def _write_spec(market: str, text: str) -> Path:
+    spec = Path("specs") / f"{market}.yaml"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text(text)
+    return spec
+
+
+def test_skip_generation_when_no_changes(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _create_market(Path("results/crypto"), [("close", "integer")])
+        _create_market(Path("cache/crypto"), [("close", "integer")])
+        spec = _write_spec("crypto", "old: 1")
+
+        called = False
+
+        def fake_generate(*_a, **_kw):
+            nonlocal called
+            called = True
+            return spec
+
+        monkeypatch.setattr("src.cli.generate_spec_for_market", fake_generate)
+        result = runner.invoke(cli, ["generate-if-needed", "--market", "crypto"])
+        assert result.exit_code == 0, result.output
+        assert "No changes detected" in result.output
+        assert not called
+        assert spec.read_text() == "old: 1"
+
+
+def test_generation_when_changed(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _create_market(Path("results/crypto"), [("close", "integer"), ("open", "text")])
+        _create_market(Path("cache/crypto"), [("close", "integer")])
+        spec = _write_spec("crypto", "old: 1")
+
+        def fake_generate(*_a, **_kw):
+            spec.write_text("new: 1")
+            return spec
+
+        monkeypatch.setattr("src.cli.generate_spec_for_market", fake_generate)
+        result = runner.invoke(cli, ["generate-if-needed", "--market", "crypto"])
+        assert result.exit_code == 0, result.output
+        assert "regenerating" in result.output
+        assert spec.read_text() == "new: 1"
+
+
+def test_yaml_updated_only_when_changed(monkeypatch):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _create_market(Path("results/crypto"), [("close", "integer"), ("open", "text")])
+        _create_market(Path("cache/crypto"), [("close", "integer")])
+        spec = _write_spec("crypto", "old: 1")
+
+        def fake_generate(*_a, **_kw):
+            spec.write_text("new: 1")
+            return spec
+
+        monkeypatch.setattr("src.cli.generate_spec_for_market", fake_generate)
+        result = runner.invoke(cli, ["generate-if-needed", "--market", "crypto"])
+        assert result.exit_code == 0, result.output
+        first_mtime = spec.stat().st_mtime
+
+        # run again with no changes
+        _create_market(Path("cache/crypto"), [("close", "integer"), ("open", "text")])
+        result = runner.invoke(cli, ["generate-if-needed", "--market", "crypto"])
+        assert result.exit_code == 0, result.output
+        assert "No changes detected" in result.output
+        assert spec.stat().st_mtime == first_mtime


### PR DESCRIPTION
## Summary
- add `generate-if-needed` CLI command for conditional spec generation
- update `codex_actions.py` with `generate_if_needed` helper
- regenerate README with new CLI command
- bump version to 1.0.48
- add tests for conditional generation
- regenerate OpenAPI specs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f3b1ef9dc832c92c6dd3d7aadebdc