### PR TITLE
Add publishing commands and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 🧠 **tv-generator** — это CLI-инструмент для автоматической генерации OpenAPI 3.1 спецификаций на основе TradingView API `/scan` и `/metainfo`.
 
+🔗 Онлайн OpenAPI: [crypto.yaml](https://trololobird.github.io/tv-generator/specs/crypto.yaml)
+
 ## 📦 Установка
 
 ```bash
@@ -39,6 +41,8 @@ tvgen validate --spec specs/crypto.yaml
 - `metainfo` - Fetch metainfo for given market via /{market}/metainfo.
 - `preview` - Show table with fields, type, enum and description.
 - `price` - Fetch last close price for a symbol.
+- `publish-pages` - Publish YAML specs to GitHub Pages branch.
+- `publish-release-assets` - Upload specs to GitHub release.
 - `recommend` - Fetch trading recommendation for a symbol.
 - `refresh` - Download latest data and update TSV files.
 - `scan` - Perform a basic scan request and print JSON.
@@ -46,6 +50,13 @@ tvgen validate --spec specs/crypto.yaml
 - `summary` - Call /{market}/summary with the given payload.
 - `validate` - Validate an OpenAPI specification file.
 - `version` - Show current package version.
+
+## Публикация спецификаций
+
+```bash
+tvgen publish-pages --branch gh-pages
+tvgen publish-release-assets --tag v1.0.48
+```
 
 ## 📁 Структура проекта
 

--- a/src/docs/readme_generator.py
+++ b/src/docs/readme_generator.py
@@ -26,6 +26,11 @@ def generate_readme(path: Path = Path("README.generated.md")) -> Path:
         "`/scan` и `/metainfo`."
     )
     lines.append("")
+    lines.append(
+        "🔗 Онлайн OpenAPI: "
+        "[crypto.yaml](https://trololobird.github.io/tv-generator/specs/crypto.yaml)"
+    )
+    lines.append("")
     lines.append("## 📦 Установка")
     lines.append("")
     lines.extend(
@@ -57,6 +62,17 @@ def generate_readme(path: Path = Path("README.generated.md")) -> Path:
     for name, help_text in _list_commands():
         lines.append(f"- `{name}` - {help_text}")
     lines.append("")
+    lines.append("## Публикация спецификаций")
+    lines.append("")
+    lines.extend(
+        [
+            "```bash",
+            "tvgen publish-pages --branch gh-pages",
+            "tvgen publish-release-assets --tag v1.0.48",
+            "```",
+            "",
+        ]
+    )
     lines.append("## 📁 Структура проекта")
     lines.append("")
     lines.extend(


### PR DESCRIPTION
## Summary
- add `publish-pages` and `publish-release-assets` commands
- generate docs with new publishing section
- test the new CLI commands

## Testing
- `flake8 .`
- `mypy src/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f3e5a61fc832c9a8cf507760ea0db