### PR TITLE
Optimize CLI tests

### DIFF
--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -89,22 +89,6 @@ def test_generate_invalid_market() -> None:
     assert "Invalid value for '--market'" in result.output
 
 
-def test_collect_and_generate(monkeypatch) -> None:
-    runner = CliRunner()
-    _mock_collect_api(monkeypatch)
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["collect", "--market", "crypto"])
-        assert result.exit_code == 0, result.output
-        result = runner.invoke(
-            cli,
-            ["generate", "--market", "crypto", "--indir", "results", "--outdir", "."],
-        )
-        assert result.exit_code == 0, result.output
-        text = Path("crypto.yaml").read_text()
-        assert "PLACEHOLDER" not in text
-        assert "TODO" not in text
-
-
 def test_collect_invalid_market() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["collect", "--market", "bad"])

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,7 +7,7 @@ from openapi_spec_validator import validate_spec
 from src.cli import cli
 
 
-def test_e2e_collect_and_generate(tmp_path, monkeypatch):
+def test_cli_e2e_collect_generate_validate(monkeypatch) -> None:
     meta = {
         "data": {
             "fields": [
@@ -59,7 +59,14 @@ def test_e2e_collect_and_generate(tmp_path, monkeypatch):
         )
         assert result.exit_code == 0
 
-        spec = yaml.safe_load(spec_file.read_text())
+        result = runner.invoke(cli, ["validate", "--spec", str(spec_file)])
+        assert result.exit_code == 0
+
+        text = spec_file.read_text()
+        assert "PLACEHOLDER" not in text
+        assert "TODO" not in text
+
+        spec = yaml.safe_load(text)
         validate_spec(spec)
         fields = spec["components"]["schemas"]["CryptoFields"]["properties"]
         assert set(fields) == {


### PR DESCRIPTION
## Summary
- consolidate CLI collect→generate→validate flow into a single e2e test
- drop redundant helper and old duplicate tests

## Testing
- `black tests/test_cli.py tests/test_cli_additional.py tests/test_e2e.py`
- `pytest --cov=src -q`
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f5c0ac344832cabe65c6a7417ec9e