### PR TITLE
Add mock metainfo fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         - name: Format
           run: black --check .
       - name: Lint
-        run: flake8 .
+        run: flake8 src tests
       - name: Type check
         run: mypy --strict src/
       - name: Test with coverage
@@ -122,7 +122,7 @@ jobs:
           pip install flake8 pytest -r requirements.txt
           pip install -e .
       - name: Lint
-        run: flake8 .
+        run: flake8 src tests
       - name: Test
         run: |
           PYTHONPATH=$PWD pytest -q

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ tvgen generate --market crypto --outdir specs
 tvgen validate --spec specs/crypto.yaml
 ```
 
+If `results/<market>/metainfo.json` is missing, a mock file will be created and
+generation will be skipped with a warning.
+
 Однострочный пример: `tvgen generate --market crypto --outdir specs`
 
 ## 🛠️ CLI команды

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ types-PyYAML
 types-toml
 pytest
 black
+flake8

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -31,19 +31,19 @@ def generate_spec_for_all_markets(
     """Generate specs for all markets under ``indir``."""
     out_files: List[Path] = []
     for market in detect_all_markets(indir):
-        out_files.append(
-            generate_spec_for_market(
-                market,
-                indir,
-                outdir,
-                max_size,
-                include_missing=include_missing,
-                include_types=include_types,
-                exclude_types=exclude_types,
-                only_timeframe_supported=only_timeframe_supported,
-                only_daily=only_daily,
-            )
+        result = generate_spec_for_market(
+            market,
+            indir,
+            outdir,
+            max_size,
+            include_missing=include_missing,
+            include_types=include_types,
+            exclude_types=exclude_types,
+            only_timeframe_supported=only_timeframe_supported,
+            only_daily=only_daily,
         )
+        if result is not None:
+            out_files.append(result)
     return out_files
 
 
@@ -58,7 +58,7 @@ def generate_spec_for_market(
     exclude_types: tuple[str, ...] = (),
     only_timeframe_supported: bool = False,
     only_daily: bool = False,
-) -> Path:
+) -> Path | None:
     """Generate spec for a single market."""
 
     return generate_for_market(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -199,9 +199,8 @@ def test_cli_generate_missing_results(tmp_path: Path) -> None:
                 str(Path(".")),
             ],
         )
-        assert result.exit_code != 0
-        assert result.exception is not None
-        assert "No such file" in result.output
+        assert result.exit_code == 0
+        assert "No symbols found in metainfo" in result.stderr
 
 
 def test_cli_scan_error(tv_api_mock) -> None:
@@ -237,6 +236,13 @@ def test_cli_validate_missing_file() -> None:
     assert result.exit_code != 0
     assert result.exception is not None
     assert "No such file" in result.output
+
+
+def test_cli_validate_missing_option() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["validate"])
+    assert result.exit_code != 0
+    assert "--spec is required" in result.output
 
 
 def test_cli_validate_invalid_yaml(tmp_path: Path) -> None:

--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -14,7 +14,8 @@ def _create_metainfo(path: Path) -> None:
             "fields": [
                 {"name": "close", "type": "integer"},
                 {"name": "open", "type": "text"},
-            ]
+            ],
+            "index": {"names": ["AAA"]},
         }
     }
     path.write_text(json.dumps(data))
@@ -132,6 +133,17 @@ def test_build_parallel(monkeypatch) -> None:
         assert result.exit_code == 0, result.output
         assert Path("specs/coin.yaml").exists()
         assert Path("specs/stocks.yaml").exists()
+
+
+def test_build_no_metainfo(monkeypatch) -> None:
+    runner = CliRunner()
+    monkeypatch.setattr("src.constants.SCOPES", ["coin"])
+    monkeypatch.setattr(collect_cmd, "callback", lambda *a, **kw: None)
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["build"])
+        assert result.exit_code == 0
+        assert "No symbols found in metainfo" in result.stderr
+        assert not Path("specs/coin.yaml").exists()
 
 
 def test_preview() -> None:

--- a/tests/test_field_classifier.py
+++ b/tests/test_field_classifier.py
@@ -43,7 +43,8 @@ def _prepare_files(base: Path) -> None:
                 {"name": "RSI|1D", "type": "number"},
                 {"name": "ADX|60", "type": "number"},
                 {"name": "sector", "type": "text"},
-            ]
+            ],
+            "index": {"names": ["AAA"]},
         }
     }
     (base / "metainfo.json").write_text(json.dumps(meta))

--- a/tests/test_spec_version.py
+++ b/tests/test_spec_version.py
@@ -9,7 +9,12 @@ from src.meta import versioning
 
 def _create_metainfo(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    data = {"data": {"fields": [{"name": "close", "type": "integer"}]}}
+    data = {
+        "data": {
+            "fields": [{"name": "close", "type": "integer"}],
+            "index": {"names": ["AAA"]},
+        }
+    }
     path.write_text(json.dumps(data))
     scan = {"count": 1, "data": [{"s": "AAA", "d": [1]}]}
     (path.parent / "scan.json").write_text(json.dumps(scan))


### PR DESCRIPTION
## Summary
- add metainfo stubs to generator
- show helpful message for `tvgen validate` without --spec
- skip generation when metainfo has no symbols
- update CI lint step and include flake8 in requirements
- document mock behaviour in README
- adjust tests for new behaviour

## Testing
- `black . --check`
- `flake8 src tests`
- `mypy src`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6aceee94832ca95adac8b7facf6c