### PR TITLE
Add type hints to utils and data modules

### DIFF
--- a/src/utils/custom_patterns.py
+++ b/src/utils/custom_patterns.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import re
+from typing import List
 
-_CUSTOM_PATTERNS = [r"^TV_Custom\.", r"_impact_score$", r"^BTC_", r"^custom_"]
+_CUSTOM_PATTERNS: List[str] = [
+    r"^TV_Custom\.",
+    r"_impact_score$",
+    r"^BTC_",
+    r"^custom_",
+]
 
 
 def _is_custom(name: str) -> bool:

--- a/src/utils/payload.py
+++ b/src/utils/payload.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, List
 
 
 def build_scan_payload(
@@ -13,7 +13,7 @@ def build_scan_payload(
 ) -> Dict[str, Any]:
     """Return a scan payload for the given symbols and columns."""
 
-    symbols_list = list(symbols)
+    symbols_list: List[str] = list(symbols)
 
     def _normalize(col: str) -> str:
         """Strip multi-day/week timeframe suffixes from the column name."""
@@ -23,7 +23,7 @@ def build_scan_payload(
                 return base
         return col
 
-    columns_list = [_normalize(c) for c in columns]
+    columns_list: List[str] = [_normalize(c) for c in columns]
 
     if not symbols_list:
         raise ValueError("symbols list cannot be empty")
@@ -32,7 +32,7 @@ def build_scan_payload(
     if len(set(columns_list)) != len(columns_list):
         raise ValueError("columns list contains duplicates")
 
-    payload = {
+    payload: Dict[str, Any] = {
         "symbols": {"tickers": symbols_list, "query": {"types": []}},
         "columns": columns_list,
     }

--- a/src/utils/type_mapping.py
+++ b/src/utils/type_mapping.py
@@ -1,7 +1,9 @@
 """Mappings between TradingView types and OpenAPI schema references."""
 
+from typing import Dict
+
 # TradingView type to OpenAPI component reference mapping
-TV_TYPE_TO_REF: dict[str, str] = {
+TV_TYPE_TO_REF: Dict[str, str] = {
     "number": "#/components/schemas/Num",
     "price": "#/components/schemas/Num",
     "fundamental_price": "#/components/schemas/Num",


### PR DESCRIPTION
## Summary
- type annotate custom pattern utilities
- annotate payload builder internals
- add explicit typing to TV type mapping
- expand typing in data collector

## Testing
- `black .`
- `flake8 .`
- `mypy src/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850bbaf19bc832c9d75aeccf4b98b64