### PR TITLE
Add docstrings for utility modules

### DIFF
--- a/src/data/collector.py
+++ b/src/data/collector.py
@@ -2,6 +2,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List
 
+"""Utilities for fetching TradingView metadata and scan results."""
+
 import pandas as pd
 
 import requests
@@ -14,7 +16,23 @@ logger = logging.getLogger(__name__)
 
 
 def refresh_market(market: str, outdir: Path | str = "results") -> None:
-    """Refresh TradingView data for ``market`` into ``outdir`` directory."""
+    """Download and store TradingView data for a market.
+
+    Parameters
+    ----------
+    market : str
+        Market identifier used by TradingView (e.g. ``"crypto"``).
+    outdir : Path | str, optional
+        Directory where the ``metainfo.json``, ``scan.json`` and
+        ``field_status.tsv`` files will be written. Defaults to ``"results"``.
+
+    Raises
+    ------
+    requests.exceptions.RequestException
+        If any network request fails.
+    ValueError
+        If the received data is malformed.
+    """
 
     outdir = Path(outdir)
     market_dir = outdir / market

--- a/src/utils/custom_patterns.py
+++ b/src/utils/custom_patterns.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from typing import List
 
+"""Helper utilities for detecting TradingView custom field names."""
+
 _CUSTOM_PATTERNS: List[str] = [
     r"^TV_Custom\.",
     r"_impact_score$",
@@ -12,6 +14,20 @@ _CUSTOM_PATTERNS: List[str] = [
 
 
 def _is_custom(name: str) -> bool:
+    """Return ``True`` if ``name`` looks like a custom TradingView field.
+
+    Parameters
+    ----------
+    name : str
+        Field name from TradingView metainfo or scan results.
+
+    Returns
+    -------
+    bool
+        ``True`` if the name matches any of the known custom patterns,
+        otherwise ``False``.
+    """
+
     for pat in _CUSTOM_PATTERNS:
         if re.search(pat, name, re.IGNORECASE):
             return True

--- a/src/utils/payload.py
+++ b/src/utils/payload.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List
 
+"""Helpers for building TradingView scan request payloads."""
+
 
 def build_scan_payload(
     symbols: Iterable[str],
@@ -11,7 +13,35 @@ def build_scan_payload(
     sort: Dict[str, Any] | None = None,
     range_: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
-    """Return a scan payload for the given symbols and columns."""
+    """Return a payload suitable for TradingView ``/scan`` requests.
+
+    Parameters
+    ----------
+    symbols : Iterable[str]
+        Iterable of ticker symbols.
+    columns : Iterable[str]
+        Iterable of requested field names.
+    filter_ : dict[str, Any] | None, optional
+        Mapping for the ``filter`` section.
+    filter2 : dict[str, Any] | None, optional
+        Mapping for the ``filter2`` section.
+    sort : dict[str, Any] | None, optional
+        Sort specification.
+    range_ : dict[str, Any] | None, optional
+        Range specification.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary ready to be posted to the TradingView API.
+
+    Raises
+    ------
+    ValueError
+        If ``symbols`` or ``columns`` are empty or contain duplicates.
+    TypeError
+        If ``filter_``, ``filter2``, ``sort`` or ``range_`` are not mappings.
+    """
 
     symbols_list: List[str] = list(symbols)
 

--- a/src/utils/type_mapping.py
+++ b/src/utils/type_mapping.py
@@ -26,7 +26,19 @@ TV_TYPE_TO_REF: Dict[str, str] = {
 
 
 def tv2ref(tv_type: str) -> str:
-    """Return an OpenAPI schema reference for a TradingView type."""
+    """Return the OpenAPI schema reference for a TradingView type.
+
+    Parameters
+    ----------
+    tv_type : str
+        Type name as used in TradingView metainfo.
+
+    Returns
+    -------
+    str
+        The corresponding ``#/components/schemas`` reference. Unknown
+        types fall back to ``Str`` and trigger a :class:`RuntimeWarning`.
+    """
     try:
         return TV_TYPE_TO_REF[tv_type]
     except KeyError:


### PR DESCRIPTION
## Summary
- document all utils, data and meta modules
- include parameter and return details in docstrings

## Testing
- `black .`
- `flake8 .`
- `mypy src`
- `pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6850bd4e9b8c832c884e920be57a32ed