### PR TITLE
Bundle codex_actions locally for workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.51 - 2025-06-18
+- Automated update
 ## 1.0.50
 - Fix package configuration to exclude missing `src.constants` directory
 

--- a/codex_actions/__init__.py
+++ b/codex_actions/__init__.py
@@ -1,0 +1,48 @@
+import subprocess
+from pathlib import Path
+import datetime
+import toml
+
+
+def _run(cmd):
+    subprocess.run(cmd, check=True)
+
+
+def generate_openapi_spec():
+    _run(["tvgen", "generate", "--market", "crypto", "--outdir", "specs"])
+
+
+def validate_spec():
+    _run(["tvgen", "validate", "--spec", "specs/crypto.yaml"])
+
+
+def run_tests():
+    _run(["pytest", "-q"])
+
+
+def format_code():
+    _run(["black", "."])
+
+
+def bump_version():
+    pyproject = Path("pyproject.toml")
+    data = toml.loads(pyproject.read_text())
+    version = data["project"]["version"]
+    parts = version.split(".")
+    if len(parts) == 3:
+        parts[-1] = str(int(parts[-1]) + 1)
+    else:
+        parts.append("1")
+    new_version = ".".join(parts)
+    data["project"]["version"] = new_version
+    pyproject.write_text(toml.dumps(data))
+
+    changelog = Path("CHANGELOG.md")
+    date = datetime.date.today().isoformat()
+    changelog.write_text(
+        f"\n## {new_version} - {date}\n- Automated update\n" + changelog.read_text()
+    )
+
+
+def create_pull_request(title: str, body: str):
+    _run(["gh", "pr", "create", "--title", title, "--body", body])

--- a/codex_actions/pyproject.toml
+++ b/codex_actions/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "codex_actions"
+version = "0.1.0"
+
+[tool.setuptools]
+packages = ["codex_actions"]
+[tool.setuptools.package-dir]
+codex_actions = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,18 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.50"
+version = "1.0.51"
 requires-python = ">=3.10"
-dependencies = [
-  "click==8.2.1",
-  "requests==2.32.4",
-  "pandas==2.3.0",
-  "PyYAML==6.0.2",
-  "openapi-spec-validator==0.7.2",
-  "toml==0.10.2",
-  "requests_cache==1.2.1",
-  "pydantic==2.11.7",
-]
+dependencies = [ "click==8.2.1", "requests==2.32.4", "pandas==2.3.0", "PyYAML==6.0.2", "openapi-spec-validator==0.7.2", "toml==0.10.2", "requests_cache==1.2.1", "pydantic==2.11.7",]
 
 [project.scripts]
 tvgen = "src.cli:cli"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ flake8==7.2.0
 mypy==1.9.0
 coverage
 Sphinx==7.2.6
+-e ./codex_actions

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ click==8.2.1
 toml==0.10.2
 requests_cache==1.2.1
 pydantic==2.11.7
+-e ./codex_actions


### PR DESCRIPTION
## Summary
- include a local `codex_actions` package with helper actions
- install it via requirements files
- bump version to 1.0.51

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `flake8 .`
- `mypy src/`
- `PYTHONPATH=$PWD pytest -q`
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_685225ae2a6c832cab015fc67cf257b1