### PR TITLE
Fix codex_actions install in workflow

### DIFF
--- a/.github/workflows/generate-specs.yml
+++ b/.github/workflows/generate-specs.yml
@@ -27,6 +27,7 @@ jobs:
           pip install -r requirements.txt
           pip install -e .
           pip install black
+          pip install codex_actions
       - name: Run codex actions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- install `codex_actions` in `generate-specs.yml` so the workflow finds the package

## Testing
- `black .`
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `tvgen generate --market crypto --outdir specs` *(warns no symbols found)*
- `tvgen validate --spec specs/crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_685270c10d0c832c83dddb45290a3a1f