### PR TITLE
Fix install deps for generate-specs workflow

### DIFF
--- a/.github/workflows/generate-specs.yml
+++ b/.github/workflows/generate-specs.yml
@@ -28,6 +28,7 @@ jobs:
           pip install -e .
           pip install black
           pip install codex_actions
+          pip install pytest
       - name: Run codex actions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- ensure pytest is installed in `generate-specs` workflow

## Testing
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685272cf2c34832cb98f549193c4e6fa