### PR TITLE
Fix Python version for spec workflow

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -21,7 +21,7 @@ jobs:
       SERVER_URL: ${{ secrets.SERVER_URL }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ['3.10']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.52 - 2025-06-18
+- Automated update
 ## 1.0.51 - 2025-06-18
 - Automated update
 ## 1.0.50

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.51"
+version = "1.0.52"
 requires-python = ">=3.10"
-dependencies = [ "click==8.2.1", "requests==2.32.4", "pandas==2.3.0", "PyYAML==6.0.2", "openapi-spec-validator==0.7.2", "toml==0.10.2", "requests_cache==1.2.1", "pydantic==2.11.7",]
+dependencies = [ "click==8.2.1", "requests==2.32.4", "pandas==2.3.0", "PyYAML==6.0.2", "openapi-spec-validator==0.7.2; python_version < '4.0'", "toml==0.10.2", "requests_cache==1.2.1", "pydantic==2.11.7",]
 
 [project.scripts]
 tvgen = "src.cli:cli"


### PR DESCRIPTION
## Summary
- pin Python version to 3.10 in spec-update workflow
- add Python <4 marker for `openapi-spec-validator`
- bump version to 1.0.52

## Testing
- `black .`
- `flake8 .`
- `mypy src`
- `pytest -q` *(fails: 27 errors during collection)*
- `tvgen generate --market crypto --outdir specs`
- `tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6852743d8f40832c88991c7f53587cbf