### PR TITLE
Fix pytest env for Codex run_tests

### DIFF
--- a/codex_actions/__init__.py
+++ b/codex_actions/__init__.py
@@ -1,11 +1,12 @@
 import subprocess
+import os
 from pathlib import Path
 import datetime
 import toml
 
 
-def _run(cmd):
-    subprocess.run(cmd, check=True)
+def _run(cmd, *, env=None):
+    subprocess.run(cmd, check=True, env=env)
 
 
 def generate_openapi_spec():
@@ -17,7 +18,9 @@ def validate_spec():
 
 
 def run_tests():
-    _run(["pytest", "-v"])
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path.cwd())
+    _run(["pytest", "-v"], env=env)
 
 
 def format_code():


### PR DESCRIPTION
## Summary
- ensure `run_tests` sets `PYTHONPATH`
- allow `_run` to pass environment variables

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `python - <<'PY'
import codex_actions as ca
ca.run_tests()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68528f564a3c832caad4a6924c55bd70