### PR TITLE
Fix CI test logging

### DIFF
--- a/.github/workflows/generate-specs.yml
+++ b/.github/workflows/generate-specs.yml
@@ -47,7 +47,11 @@ jobs:
 
           generate_openapi_spec()
           validate_spec()
-          run_tests()
+          try:
+              run_tests()
+          except subprocess.CalledProcessError as e:
+              print(f"Test suite failed: {e}")
+              raise
           format_code()
           bump_version()
 


### PR DESCRIPTION
## Summary
- log test failure message in generate-specs workflow

## Testing
- `black --check .`
- `PYTHONPATH=$PWD pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_685290b54a20832c8da8947cf5fcec73