### PR TITLE
Improve test command error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+
+## 1.0.53 - 2025-06-18
+- Automated update
 # Changelog
 ## 1.0.52 - 2025-06-18
 - Automated update

--- a/codex_actions/__init__.py
+++ b/codex_actions/__init__.py
@@ -6,7 +6,13 @@ import toml
 
 
 def _run(cmd, *, env=None):
-    subprocess.run(cmd, check=True, env=env)
+    try:
+        subprocess.run(cmd, check=True, env=env)
+    except subprocess.CalledProcessError as e:
+        print(f"Command '{e.cmd}' failed with exit code {e.returncode}")
+        if hasattr(e, "output") and e.output:
+            print(e.output)
+        raise
 
 
 def generate_openapi_spec():
@@ -20,7 +26,11 @@ def validate_spec():
 def run_tests():
     env = os.environ.copy()
     env["PYTHONPATH"] = str(Path.cwd())
-    _run(["pytest", "-v"], env=env)
+    try:
+        _run(["pytest", "-q"], env=env)
+    except Exception:
+        print("Tests failed. Debugging required.")
+        raise
 
 
 def format_code():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tv-generator"
-version = "1.0.52"
+version = "1.0.53"
 requires-python = ">=3.10"
 dependencies = [ "click==8.2.1", "requests==2.32.4", "pandas==2.3.0", "PyYAML==6.0.2", "openapi-spec-validator==0.7.2; python_version < '4.0'", "toml==0.10.2", "requests_cache==1.2.1", "pydantic==2.11.7",]
 


### PR DESCRIPTION
## Summary
- handle subprocess errors in `_run` for easier debugging
- report test failures in `run_tests`
- bump patch version

## Testing
- `python -m codex_actions.run_tests`
- `python - <<'PY'
from codex_actions import generate_openapi_spec, validate_spec
generate_openapi_spec(); validate_spec()
PY
`

------
https://chatgpt.com/codex/tasks/task_e_685292731434832cada26a4b85420b24