### PR TITLE
Improve pytest execution feedback

### DIFF
--- a/codex_actions/__init__.py
+++ b/codex_actions/__init__.py
@@ -27,8 +27,11 @@ def run_tests():
     env = os.environ.copy()
     env["PYTHONPATH"] = str(Path.cwd())
     try:
-        _run(["pytest", "-q"], env=env)
-    except Exception:
+        _run(["pytest", "-v", "--tb=short"], env=env)
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 4:
+            print("No tests were found or pytest configuration failed.")
+            return
         print("Tests failed. Debugging required.")
         raise
 


### PR DESCRIPTION
## Summary
- add verbose output for running tests
- handle pytest exit code `4` with a helpful message

## Testing
- `black codex_actions/__init__.py`
- `flake8 codex_actions/__init__.py`
- `mypy src`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852939f38d0832cac6888e619c39d22