### PR TITLE
Improve security checks and credential handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         - name: Install dependencies
           run: |
             python -m pip install --upgrade pip
-            pip install black flake8 mypy pytest coverage openapi-spec-validator requests_mock \
+            pip install black flake8 mypy pytest coverage openapi-spec-validator bandit safety requests_mock \
               types-requests types-PyYAML types-toml -r requirements.txt
             pip install -e .
         - name: Validate repository specs
@@ -38,8 +38,12 @@ jobs:
             if ls specs/*.yaml 1> /dev/null 2>&1; then
               openapi-spec-validator specs/*.yaml
             fi
-        - name: Format
-          run: black --check .
+      - name: Format
+        run: black --check .
+      - name: Security - Bandit
+        run: bandit -q -r src
+      - name: Security - Safety
+        run: safety check -r requirements.txt -r requirements-dev.txt
       - name: Lint
         run: flake8 src tests
       - name: Type check
@@ -122,7 +126,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest -r requirements.txt
+          pip install flake8 pytest bandit safety -r requirements.txt
           pip install -e .
       - name: Lint
         run: flake8 src tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,12 @@ repos:
     rev: v1.9.0
     hooks:
       - id: mypy
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.8
+    hooks:
+      - id: bandit
+        args: [-q, -r, src]
+  - repo: https://github.com/pycqa/safety
+    rev: 3.2.0
+    hooks:
+      - id: safety

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ tvgen generate --market crypto --outdir specs
 tvgen validate --spec specs/crypto.yaml
 ```
 
+### Configuration
+
+The CLI optionally uses a ``TV_API_TOKEN`` environment variable for
+authenticated requests. If set, the token must be at least ten characters
+long. Example:
+
+```bash
+export TV_API_TOKEN=super_secret_token
+```
+
 If `results/<market>/metainfo.json` is missing, a mock file will be created and
 generation will be skipped with a warning.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,17 @@ build-backend = "setuptools.build_meta"
 name = "tv-generator"
 version = "1.0.53"
 requires-python = ">=3.10"
-dependencies = [ "click==8.2.1", "requests==2.32.4", "pandas==2.3.0", "PyYAML==6.0.2", "openapi-spec-validator==0.7.2; python_version < '4.0'", "toml==0.10.2", "requests_cache==1.2.1", "pydantic==2.11.7",]
+dependencies = [
+    "click==8.2.1",
+    "requests==2.32.4",
+    "pandas==2.3.0",
+    "PyYAML==6.0.2",
+    "openapi-spec-validator==0.7.2; python_version < '4.0'",
+    "toml==0.10.2",
+    "requests_cache==1.2.1",
+    "pydantic==2.11.7",
+    "pydantic-settings==2.2.1",
+]
 
 [project.scripts]
 tvgen = "src.cli:cli"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,6 @@ flake8==7.2.0
 mypy==1.9.0
 coverage
 Sphinx==7.2.6
+bandit==1.7.8
+safety==3.2.0
 -e ./codex_actions

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ click==8.2.1
 toml==0.10.2
 requests_cache==1.2.1
 pydantic==2.11.7
+pydantic-settings==2.2.1
 -e ./codex_actions

--- a/src/api/tradingview_api.py
+++ b/src/api/tradingview_api.py
@@ -7,6 +7,8 @@ import requests
 from requests.adapters import HTTPAdapter, Retry
 import requests_cache
 
+from src.config import settings
+
 from src.constants import SCOPES
 from pydantic import ValidationError
 from src.models import (
@@ -65,6 +67,8 @@ class TradingViewAPI:
         adapter = HTTPAdapter(max_retries=retry)
         self.session.mount("https://", adapter)
         self.session.headers.setdefault("User-Agent", "tv-generator")
+        if settings.tv_api_token:
+            self.session.headers["Authorization"] = f"Bearer {settings.tv_api_token}"
         self.base_url = base_url or os.environ.get("TV_BASE_URL", self.BASE_URL)
         self.timeout = int(os.environ.get("TV_TIMEOUT", timeout))
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,29 @@
+"""Configuration management for tv-generator.
+
+This module provides a single :class:`Settings` instance that loads
+configuration from environment variables using pydantic's
+:class:`BaseSettings`. Currently only the ``TV_API_TOKEN`` variable is
+supported and, if set, must be at least 10 characters long.  The loaded
+settings are used across the code base and should never be printed to
+logs.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    tv_api_token: str | None = Field(default=None, env="TV_API_TOKEN")
+
+    @field_validator("tv_api_token")
+    def _validate_token(cls, value: str | None) -> str | None:
+        if value is not None and len(value) < 10:
+            raise ValueError("TV_API_TOKEN too short")
+        return value
+
+
+settings = Settings()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+from importlib import reload
+
+import pytest
+
+import importlib
+
+import src.config as config
+import src.api.tradingview_api as api_module
+
+
+def test_api_uses_token(monkeypatch) -> None:
+    monkeypatch.setenv("TV_API_TOKEN", "x" * 20)
+    reload(config)
+    importlib.reload(api_module)
+    api = api_module.TradingViewAPI()
+    assert (
+        api.session.headers.get("Authorization")
+        == f"Bearer {api_module.settings.tv_api_token}"
+    )
+
+
+def test_token_validation(monkeypatch) -> None:
+    monkeypatch.setenv("TV_API_TOKEN", "short")
+    with pytest.raises(ValueError):
+        reload(config)


### PR DESCRIPTION
## Summary
- add new Settings module for env config
- inject optional API token into TradingView requests
- integrate bandit and safety in pre-commit and CI
- mention TV_API_TOKEN in README
- add tests for new config logic

## Testing
- `black .`
- `flake8 src tests`
- `mypy --strict src/` *(fails: 6 errors)*
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68529835c4e8832c919da459c93731f8