### PR TITLE
Refactor CLI collect logic

### DIFF
--- a/src/utils/fs.py
+++ b/src/utils/fs.py
@@ -1,0 +1,41 @@
+"""File system helper utilities."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Any
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+def load_json(path: Path, max_size: int = 1_048_576) -> Any:
+    """Load JSON file with a size limit.
+
+    Args:
+        path: Path to the JSON file.
+        max_size: Maximum allowed file size in bytes.
+
+    Returns:
+        Parsed JSON object.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        click.ClickException: If JSON is invalid or the file exceeds ``max_size``.
+    """
+
+    size = os.stat(path).st_size
+    if size > max_size:
+        logger.error("File too large: %s (%d bytes)", path, size)
+        raise click.ClickException(f"File too large: {path}")
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except JSONDecodeError as exc:
+        logger.error("Failed to parse JSON from %s: %s", path, exc)
+        raise click.ClickException(f"Invalid JSON in {path}") from exc

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -1,0 +1,32 @@
+"""Logging utilities used across CLI commands."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def setup_logging(verbose: bool) -> None:
+    """Configure basic logging for the application.
+
+    Args:
+        verbose: If ``True`` enable debug level, otherwise info.
+    """
+
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s %(message)s")
+
+
+def log_exception(exc: Exception, log_path: Path) -> None:
+    """Append exception information to ``log_path``.
+
+    Args:
+        exc: The exception instance to log.
+        log_path: File path where the log should be appended.
+    """
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a") as fh:
+        fh.write(f"{type(exc).__name__}: {exc}\n")


### PR DESCRIPTION
## Summary
- add helper utilities for file IO and logging
- split collect() into smaller helpers
- use central logging setup
- preserve traceback in build when --debug is used

## Testing
- `black . --quiet`
- `flake8 .`
- `mypy src`
- `PYTHONPATH=$PWD pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6852a06de158832c8e205d44760e7415