### PR TITLE
Improve TradingView API error handling

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -18,6 +18,7 @@ from openapi_spec_validator.exceptions import OpenAPISpecValidatorError
 from pydantic import ValidationError
 
 from src.api.tradingview_api import TradingViewAPI
+from src.exceptions import TVConnectionError
 from src.utils.payload import build_scan_payload
 from src.generator.yaml_generator import generate_for_market
 from src.spec.generator import (
@@ -61,7 +62,7 @@ def _with_error_handling(
 
     try:
         return func(*args, **kwargs)
-    except requests.exceptions.RequestException as exc:
+    except (requests.exceptions.RequestException, TVConnectionError) as exc:
         logger.error("%s: %s", request_msg, exc)
         raise click.ClickException("TradingView request failed")
     except (ValidationError, KeyError) as exc:

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,2 +1,18 @@
 class TVDataError(Exception):
     """Raised when data refresh fails."""
+
+
+class TVConnectionError(Exception):
+    """Raised when TradingView API request fails."""
+
+    def __init__(
+        self, status: int, url: str, method: str, reason: str | None = None
+    ) -> None:
+        self.status = status
+        self.url = url
+        self.method = method.upper()
+        self.reason = reason
+        message = f"HTTP {status} for {self.method} {url}"
+        if reason:
+            message += f": {reason}"
+        super().__init__(message)

--- a/tests/test_additional_api_cases.py
+++ b/tests/test_additional_api_cases.py
@@ -3,6 +3,7 @@ import requests
 import yaml
 
 from src.api.tradingview_api import TradingViewAPI
+from src.exceptions import TVConnectionError
 from src.api import data_fetcher
 from src.api.data_fetcher import fetch_metainfo, full_scan
 from src.api.data_manager import build_field_status
@@ -20,7 +21,7 @@ def test_scan_request_exception(tv_api_mock):
         exc=requests.exceptions.ConnectTimeout,
     )
     api = TradingViewAPI()
-    with pytest.raises(requests.exceptions.RequestException):
+    with pytest.raises(TVConnectionError):
         api.scan("crypto", {})
 
 

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -8,7 +8,7 @@ import requests
 import src.config as config
 import src.api.tradingview_api as api_module
 from src.data import collector
-from src.exceptions import TVDataError
+from src.exceptions import TVDataError, TVConnectionError
 
 
 def test_request_logging_sanitized(tv_api_mock, caplog):
@@ -20,7 +20,7 @@ def test_request_logging_sanitized(tv_api_mock, caplog):
     )
     api = api_module.TradingViewAPI()
     with caplog.at_level(logging.INFO):
-        with pytest.raises(ValueError):
+        with pytest.raises(TVConnectionError):
             api.search("crypto", {})
     assert not any("secret-body" in r.getMessage() for r in caplog.records)
 

--- a/tests/test_tradingview_api.py
+++ b/tests/test_tradingview_api.py
@@ -1,6 +1,7 @@
 import pytest
 from pydantic import ValidationError
 from src.api.tradingview_api import TradingViewAPI
+from src.exceptions import TVConnectionError
 
 
 @pytest.mark.parametrize(
@@ -97,7 +98,7 @@ def test_endpoint_error(tv_api_mock, endpoint):
     )
     api = TradingViewAPI()
     method = getattr(api, endpoint)
-    with pytest.raises(ValueError):
+    with pytest.raises(TVConnectionError):
         method("crypto", {})
 
 
@@ -131,9 +132,9 @@ def test_metainfo_error(tv_api_mock):
         status_code=404,
     )
     api = TradingViewAPI()
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(TVConnectionError) as exc:
         api.metainfo("crypto", {"query": ""})
-    assert "TradingView HTTP 404" in str(exc.value)
+    assert exc.value.status == 404
 
 
 def test_metainfo_invalid_schema(tv_api_mock):


### PR DESCRIPTION
## Summary
- add `TVConnectionError` for richer API error details
- enforce token length check when initializing `TradingViewAPI`
- sanitize HTTP error logging and raise `TVConnectionError`
- handle connection errors in CLI utilities
- update tests for new exception handling

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6852a37fc8bc832c89a3b2e3e70938f1