### PR TITLE
Strengthen pydantic models

### DIFF
--- a/src/generator/yaml_generator.py
+++ b/src/generator/yaml_generator.py
@@ -17,7 +17,7 @@ from src.utils.type_mapping import tv2ref
 from src.meta.versioning import get_current_version
 from src.utils.custom_patterns import _is_custom
 from src.constants import GenerationMode
-from src.utils.pathlib_ext import ensure_directory, ensure_file, market_paths
+from src.utils.pathlib_ext import ensure_file, market_paths
 
 logger = logging.getLogger(__name__)
 
@@ -541,7 +541,7 @@ def generate_for_market(
         missing fields.
     """
 
-    ensure_directory(indir)
+    indir.mkdir(parents=True, exist_ok=True)
     if max_size <= 0:
         raise ValueError("max_size must be positive")
     include_missing = include_missing or generation == "include_missing"
@@ -551,6 +551,12 @@ def generate_for_market(
     if not meta_file.exists():
         meta_file.parent.mkdir(parents=True, exist_ok=True)
         meta_file.write_text(json.dumps({"symbols": {}, "version": "mock"}))
+
+    if not scan_file.exists():
+        scan_file.write_text(json.dumps({"data": []}))
+
+    if not status_file.exists():
+        status_file.write_text("field\ttv_type\tstatus\tsample_value\n")
 
     meta_data, scan_data = _load_market_data(meta_file, scan_file, status_file)
 

--- a/src/models.py
+++ b/src/models.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast, Dict
-
-from typing import Annotated, Literal
+from typing import Annotated, Literal, cast
 
 from pydantic import (
     BaseModel,
@@ -13,6 +11,10 @@ from pydantic import (
     RootModel,
     field_validator,
 )
+
+# JSON helper types
+JSONValue = object
+JSONDict = dict[str, JSONValue]
 
 # Accepted TradingView field types
 KNOWN_FIELD_TYPES = [
@@ -61,16 +63,28 @@ FieldType = Annotated[str, FieldTypeLiteral]
 
 
 class TVBaseModel(BaseModel):
-    """Base model with compatibility helpers."""
+    """Base model with compatibility helpers.
+
+    Examples
+    --------
+    >>> TVField.model_validate({'name': 'close', 'type': 'float'})
+    TVField(n='close', t='float', interval=None, description=None, flags=None)
+    """
 
     @classmethod
-    def parse_obj(cls, obj: Any) -> "TVBaseModel":
+    def parse_obj(cls, obj: object) -> "TVBaseModel":
         """Create an instance from a parsed object (pydantic v1 style)."""
         return cls.model_validate(obj)
 
 
 class TVField(TVBaseModel):
-    """TradingView field description."""
+    """TradingView field description.
+
+    Examples
+    --------
+    >>> TVField.model_validate({"name": "close", "type": "float"})
+    TVField(n='close', t='float', interval=None, description=None, flags=None)
+    """
 
     n: Annotated[str, constr(strip_whitespace=True, min_length=1)] = Field(
         serialization_alias="name",
@@ -98,14 +112,60 @@ class TVField(TVBaseModel):
             )
         return v
 
+    @field_validator("flags", mode="before")
+    @classmethod
+    def _validate_flags(cls, v: list[str] | str | None) -> list[str] | None:
+        if v is None:
+            return None
+        if isinstance(v, str):
+            v = [v]
+        if not isinstance(v, list):
+            raise TypeError("flags must be a list of strings")
+        if not all(isinstance(item, str) and item.strip() for item in v):
+            raise ValueError("flags must contain non-empty strings")
+        return [item.strip() for item in v]
+
+    @field_validator("interval", mode="before")
+    @classmethod
+    def _validate_interval(cls, v: float | str | None) -> float | None:
+        if v is None:
+            return None
+        try:
+            value = float(v)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("interval must be a positive number") from exc
+        if value <= 0:
+            raise ValueError("interval must be positive")
+        return value
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def _validate_description(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        if not isinstance(v, str):
+            raise TypeError("description must be a string")
+        v = v.strip()
+        if not v:
+            raise ValueError("description cannot be empty")
+        return v
+
 
 class MetaInfoResponse(TVBaseModel):
-    """Response containing field metadata."""
+    """Response containing field metadata.
+
+    Examples
+    --------
+    >>> MetaInfoResponse.model_validate({
+    ...     "fields": [{"name": "close", "type": "float"}]
+    ... })
+    MetaInfoResponse(data=[TVField(n='close', t='float', interval=None, ...)])
+    """
 
     data: list[TVField]
 
     @classmethod
-    def parse_obj(cls, obj: Any) -> "MetaInfoResponse":
+    def parse_obj(cls, obj: object) -> "MetaInfoResponse":
         """Parse TradingView metainfo JSON into a model."""
         if isinstance(obj, dict):
             fields_json = None
@@ -124,14 +184,29 @@ class MetaInfoResponse(TVBaseModel):
 
 
 class ScanItem(TVBaseModel):
-    """Single scan item."""
+    """Single scan item.
+
+    Examples
+    --------
+    >>> ScanItem.model_validate({"s": "BINANCE:BTCUSD", "d": [50000.0]})
+    ScanItem(s='BINANCE:BTCUSD', d=[50000.0])
+    """
 
     s: Annotated[str, constr(strip_whitespace=True, min_length=1)]
-    d: list[object]
+    d: list[JSONValue]
 
 
 class ScanResponse(TVBaseModel):
-    """Response for scan results."""
+    """Response for scan results.
+
+    Examples
+    --------
+    >>> ScanResponse.model_validate({
+    ...     "data": [{"s": "BINANCE:BTCUSD", "d": [1]}],
+    ...     "count": 1,
+    ... })
+    ScanResponse(data=[ScanItem(s='BINANCE:BTCUSD', d=[1])], count=1)
+    """
 
     data: list[ScanItem]
     count: int | None = Field(
@@ -139,10 +214,16 @@ class ScanResponse(TVBaseModel):
     )
 
 
-class GenericResponse(RootModel[Dict[str, Any]]):
-    """Generic mapping used for search/history/summary."""
+class GenericResponse(RootModel[JSONDict]):
+    """Generic mapping used for search/history/summary.
 
-    root: Dict[str, Any]
+    Examples
+    --------
+    >>> SearchResponse.model_validate({"status": "ok"})
+    SearchResponse(root={'status': 'ok'})
+    """
+
+    root: JSONDict
 
 
 class SearchResponse(GenericResponse):


### PR DESCRIPTION
## Summary
- enforce stricter pydantic models and add usage examples
- validate `flags`, `interval` and `description` fields
- improve YAML generator fault tolerance when no data present
- add model edge case tests

## Testing
- `flake8 .`
- `mypy src/`
- `PYTHONPATH=$PWD pytest -q`
- `./tvgen generate --market crypto --outdir specs`
- `./tvgen validate --spec specs/crypto.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6852b81ffab0832cb6245488d98eccfe