### PR TITLE
Improve refresh caching and YAML loading

### DIFF
--- a/src/api/data_fetcher.py
+++ b/src/api/data_fetcher.py
@@ -9,6 +9,7 @@ import requests
 
 from src.models import MetaInfoResponse, ScanResponse
 from src.api.tradingview_api import TradingViewAPI
+from src.utils.fs import save_json as _write_json
 
 logger = logging.getLogger(__name__)
 
@@ -243,7 +244,6 @@ def full_scan(
 
 
 def save_json(data: Dict[str, Any], path: Path) -> None:
-    """Save dictionary as pretty JSON to given path."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2)
+    """Save dictionary as pretty JSON to given ``path``."""
+
+    _write_json(data, path)

--- a/src/meta/versioning.py
+++ b/src/meta/versioning.py
@@ -5,6 +5,7 @@ import datetime
 import subprocess
 import toml
 import yaml
+from src.utils.fs import load_yaml
 
 """Helpers for project version management and changelog generation."""
 
@@ -148,7 +149,7 @@ def _update_spec_files(version: str, specs_dir: Path) -> None:
 
     for spec_file in specs_dir.glob("*.yaml"):
         try:
-            data = yaml.safe_load(spec_file.read_text())
+            data = load_yaml(spec_file, max_size=5_242_880)
         except Exception:  # pragma: no cover - malformed YAML
             continue
         if isinstance(data, dict) and "info" in data:

--- a/src/spec/bundler.py
+++ b/src/spec/bundler.py
@@ -5,6 +5,8 @@ from typing import Dict, Any
 import json
 import yaml
 
+from src.utils.fs import load_yaml
+
 
 def bundle_all_specs(
     spec_dir: str | Path, outfile: str | Path, format: str = "json"
@@ -19,8 +21,7 @@ def bundle_all_specs(
     base = Path(spec_dir)
     data: Dict[str, Any] = {}
     for yaml_file in base.glob("*.yaml"):
-        with yaml_file.open("r", encoding="utf-8") as fh:
-            data[yaml_file.stem] = yaml.safe_load(fh)
+        data[yaml_file.stem] = load_yaml(yaml_file, max_size=5_242_880)
 
     out_path = Path(outfile)
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/utils/fs.py
+++ b/src/utils/fs.py
@@ -8,6 +8,7 @@ import os
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Any
+import yaml
 
 import click
 
@@ -39,3 +40,41 @@ def load_json(path: Path, max_size: int = 1_048_576) -> Any:
     except JSONDecodeError as exc:
         logger.error("Failed to parse JSON from %s: %s", path, exc)
         raise click.ClickException(f"Invalid JSON in {path}") from exc
+
+
+def save_json(data: Any, path: Path) -> None:
+    """Save *data* as pretty JSON to ``path``."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+
+
+def load_yaml(path: Path, max_size: int = 5_242_880) -> Any:
+    """Load YAML file with a size limit (default 5 MB)."""
+
+    size = os.stat(path).st_size
+    if size > max_size:
+        logger.error("YAML too large: %s (%d bytes)", path, size)
+        raise click.ClickException(f"File too large: {path}")
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        logger.error("Failed to parse YAML from %s: %s", path, exc)
+        raise click.ClickException(f"Invalid YAML in {path}") from exc
+
+
+def cleanup_cache_file(path: Path, max_size: int = 50 * 1024 * 1024) -> None:
+    """Remove cache *path* if it exceeds ``max_size`` bytes."""
+
+    if not path.exists():
+        return
+    size = path.stat().st_size
+    if size <= max_size:
+        return
+    logger.info("Clearing cache %s (%d bytes > %d)", path, size, max_size)
+    try:
+        path.unlink()
+    except OSError as exc:
+        logger.warning("Failed to delete cache %s: %s", path, exc)


### PR DESCRIPTION
## Summary
- refactor collector to return success bool and clear HTTP cache file
- unify JSON/YAML helpers in utils and limit YAML size
- update CLI to use new load_yaml and handle errors
- use load_yaml when bundling and bumping spec versions

## Testing
- `black .`
- `flake8 .`
- `mypy src/`
- `PYTHONPATH=$PWD pytest -q`
- `python -m src.cli generate --market crypto --outdir specs`
- `python -m src.cli validate --spec specs/crypto.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6852bc0eaea4832c8c7c3b805e0dd325