### PR TITLE
Improve spec build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
           else
             echo "::warning::No spec files generated to validate."
           fi
+
+      - name: Bundle specs
+        run: tvgen bundle --format yaml --outfile bundle.yaml
       - name: Check spec sizes
         run: |
           for spec in specs/*.yaml; do
@@ -97,12 +100,14 @@ jobs:
               exit 1
             fi
           done
-      - name: Upload specs as artifacts if they exist
-        if: failure() && hashFiles('specs/*') != ''
+      - name: Upload specs as artifacts
+        if: hashFiles('specs/*') != ''
         uses: actions/upload-artifact@v3
         with:
           name: generated-specs
-          path: specs/
+          path: |
+            specs/
+            bundle.yaml
           if-no-files-found: ignore
       - name: Summarize workflow
         run: |

--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -56,6 +56,12 @@ jobs:
             extra="--server-url $SERVER_URL"
           fi
           poetry run tvgen build --indir results --outdir specs $extra || { echo "tvgen build failed"; exit 1; }
+
+      - name: Log generated specs
+        run: cat specs/*.yaml || echo "No generated specs found"
+
+      - name: Bundle specs
+        run: poetry run tvgen bundle --format yaml --outfile bundle.yaml || { echo "Bundle failed"; exit 1; }
       - name: Validate all generated specs
         run: |
           for spec in specs/*.yaml; do
@@ -67,6 +73,14 @@ jobs:
         with:
           name: results
           path: results/**
+
+      - name: Upload spec artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: specs
+          path: |
+            specs/*.yaml
+            bundle.yaml
       - name: Stash changes (if any)
         run: |
           git stash --include-untracked


### PR DESCRIPTION
## Summary
- add logging, bundling and artifact upload for spec update workflow
- upload specs and bundle on CI runs

## Testing
- `flake8 .`
- `mypy src/`
- `pytest -q`
- `python - <<'PY'
from codex_actions import generate_openapi_spec, validate_spec

generate_openapi_spec()
validate_spec()
PY
`


------
https://chatgpt.com/codex/tasks/task_e_6852c7c55068832c9e354ea6c2dff40f